### PR TITLE
Fix reading Criteo dataset

### DIFF
--- a/data_utils.py
+++ b/data_utils.py
@@ -350,6 +350,7 @@ def getKaggleCriteoAdData(datafile="", o_filename=""):
         else:
             split = 1
             break
+    split = min(split, 7)
 
     count = 0
     if split == 1:


### PR DESCRIPTION
Limit `split` to be less or equal to 7 in getKaggleCriteoAdData`.

By default, script `dlrm_s_criteo_kaggle.sh` will split dataset to 7 files,
kaggle_day_1.npz, kaggle_day_2.npz ... kaggle_day_7.npz. If don't limit `split` under 8,
the script will try to read nonexistent file `./kaggle_data/kaggle_day_8.npz` when second run