### PR TITLE
Tgrel/minor mlperf fixes

### DIFF
--- a/bench/run_and_time.sh
+++ b/bench/run_and_time.sh
@@ -14,6 +14,6 @@ else
 fi
 #echo $dlrm_extra_option
 
-python dlrm_s_pytorch.py --arch-sparse-feature-size=128 --arch-mlp-bot="13-512-256-128" --arch-mlp-top="1024-1024-512-256-1" --max-ind-range=40000000 --data-generation=dataset --data-set=terabyte --raw-data-file=./input/day --processed-data-file=./input/terabyte_processed.npz --loss-function=bce --round-targets=True --learning-rate=1.0 --mini-batch-size=2048 --print-freq=2048 --print-time --test-freq=102400 --test-mini-batch-size=16384 --test-num-workers=16 --memory-map --mlperf-logging --mlperf-auc-threshold=0.8025 --mlperf-bin-file --mlperf-bin-shuffle $dlrm_extra_option 2>&1 | tee run_terabyte_mlperf_pt.log
+python dlrm_s_pytorch.py --arch-sparse-feature-size=128 --arch-mlp-bot="13-512-256-128" --arch-mlp-top="1024-1024-512-256-1" --max-ind-range=40000000 --data-generation=dataset --data-set=terabyte --raw-data-file=./input/day --processed-data-file=./input/terabyte_processed.npz --loss-function=bce --round-targets=True --learning-rate=1.0 --mini-batch-size=2048 --print-freq=2048 --print-time --test-freq=102400 --test-mini-batch-size=16384 --test-num-workers=16 --memory-map --mlperf-logging --mlperf-auc-threshold=0.8025 --mlperf-bin-loader --mlperf-bin-shuffle $dlrm_extra_option 2>&1 | tee run_terabyte_mlperf_pt.log
 
 echo "done"

--- a/dlrm_s_pytorch.py
+++ b/dlrm_s_pytorch.py
@@ -923,7 +923,7 @@ if __name__ == "__main__":
                 should_test = (
                     (args.test_freq > 0)
                     and (args.data_generation == "dataset")
-                    and (((j + 1) % args.test_freq == 0) or (j + 1 == nbatches))
+                    and (((j + 1) % args.test_freq == 0) or (j + 1 == nbatches and not args.mlperf_logging))
                 )
 
                 # print time, loss and accuracy


### PR DESCRIPTION
Fix some minor issues with the MLPerf reference:

1. Fix a typo in run_and_time.sh file
2. Don't perform additional end-of-epoch evaluation in mlperf_logging mode.