### PR TITLE
Multiple improvements to distributed code

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,33 +287,55 @@ Benchmarking
     ```
 
 2) The code supports interface with the [Criteo Kaggle Display Advertising Challenge Dataset](https://labs.criteo.com/2014/02/kaggle-display-advertising-challenge-dataset/).
-   Please do the following to prepare the dataset for use with DLRM code:
+   - Please do the following to prepare the dataset for use with DLRM code:
      - First, specify the raw data file (train.txt) as downloaded with --raw-data-file=<path/train.txt>
      - This is then pre-processed (categorize, concat across days...) to allow using with dlrm code
      - The processed data is stored as *.npz file in <root_dir>/input/*.npz
      - The processed file (*.npz) can be used for subsequent runs with --processed-data-file=<path/*.npz>
-
+   - The model can be trained using the following script
      ```
-     ./bench/dlrm_s_criteo_kaggle.sh
+     ./bench/dlrm_s_criteo_kaggle.sh [--test-freq=1024]
      ```
-
+     
 <img src="./kaggle_dac_loss_accuracy_plots.png" width="900" height="320">
 
 3) The code supports interface with the [Criteo Terabyte Dataset](https://labs.criteo.com/2013/12/download-terabyte-click-logs/).
-   Please do the following to prepare the dataset for use with DLRM code:
+   - Please do the following to prepare the dataset for use with DLRM code:
      - First, download the raw data files day_0.gz, ...,day_23.gz and unzip them
      - Specify the location of the unzipped text files day_0, ...,day_23, using --raw-data-file=<path/day> (the day number will be appended automatically)
      - These are then pre-processed (categorize, concat across days...) to allow using with dlrm code
      - The processed data is stored as *.npz file in <root_dir>/input/*.npz
      - The processed file (*.npz) can be used for subsequent runs with --processed-data-file=<path/*.npz>
-
+   - The model can be trained using the following script
     ```
-    ./bench/dlrm_s_criteo_terabyte.sh ["--memory-map --data-sub-sample-rate=0.875"]
+      ./bench/dlrm_s_criteo_terabyte.sh ["--test-freq=10240 --memory-map --data-sub-sample-rate=0.875"]
     ```
+    - Corresponding pre-trained model is available under [CC-BY-NC license](https://creativecommons.org/licenses/by-nc/2.0/) and can be downloaded here
+    [dlrm_emb64_subsample0.875_maxindrange10M_pretrained.pt](https://dlrm.s3-us-west-1.amazonaws.com/models/tb0875_10M.pt)   
 
 <img src="./terabyte_0875_loss_accuracy_plots.png" width="900" height="320">
 
 *NOTE: Benchmarking scripts accept extra arguments which will be passed along to the model, such as --num-batches=100 to limit the number of data samples*
+
+4) The code supports interface with [MLPerf benchmark](https://mlperf.org). 
+   - Please refer to the following training parameters
+   ```
+     --mlperf-logging that keeps track of multiple metrics, including area under the curve (AUC)
+   
+     --mlperf-acc-threshold that allows early stopping based on accuracy metric
+   
+     --mlperf-auc-threshold that allows early stopping based on AUC metric
+   
+     --mlperf-bin-loader that enables preprocessing of data into a single binary file
+   
+     --mlperf-bin-shuffle that controls whether a random shuffle of mini-batches is performed
+   ```
+   - The MLPerf training model is completely specified and can be trained using the following script
+   ```
+     ./bench/run_and_time.sh [--use-gpu]
+   ```
+   - Corresponding pre-trained model is available under [CC-BY-NC license](https://creativecommons.org/licenses/by-nc/2.0/) and can be downloaded here
+     [dlrm_emb128_subsample0.0_maxindrange40M_pretrained.pt](https://dlrm.s3-us-west-1.amazonaws.com/models/tb00_40M.pt)
 
 Model checkpoint saving/loading
 -------------------------------

--- a/bench/run_and_time.sh
+++ b/bench/run_and_time.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
+#WARNING: must have compiled PyTorch and caffe2
+
+#check if extra argument is passed to the test
+if [[ $# == 1 ]]; then
+    dlrm_extra_option=$1
+else
+    dlrm_extra_option=""
+fi
+#echo $dlrm_extra_option
+
+python dlrm_s_pytorch.py --arch-sparse-feature-size=128 --arch-mlp-bot="13-512-256-128" --arch-mlp-top="1024-1024-512-256-1" --max-ind-range=40000000 --data-generation=dataset --data-set=terabyte --raw-data-file=./input/day --processed-data-file=./input/terabyte_processed.npz --loss-function=bce --round-targets=True --learning-rate=1.0 --mini-batch-size=2048 --print-freq=2048 --print-time --test-freq=102400 --test-mini-batch-size=16384 --test-num-workers=16 --memory-map --mlperf-logging --mlperf-auc-threshold=0.8025 --mlperf-bin-loader --mlperf-bin-shuffle $dlrm_extra_option 2>&1 | tee run_terabyte_mlperf_pt.log
+
+echo "done"

--- a/data_loader_terabyte.py
+++ b/data_loader_terabyte.py
@@ -8,9 +8,12 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import os
 import numpy as np
+from torch.utils.data import Dataset
 import torch
 import time
 import math
+from tqdm import tqdm
+import argparse
 
 
 class DataLoader:
@@ -24,14 +27,15 @@ class DataLoader:
             data_directory,
             days,
             batch_size,
-            max_ind_range = -1,
-            split = "train",
-            drop_last_batch=True
+            max_ind_range=-1,
+            split="train",
+            drop_last_batch=False
     ):
         self.data_filename = data_filename
         self.data_directory = data_directory
         self.days = days
         self.batch_size = batch_size
+        self.max_ind_range = max_ind_range
 
         total_file = os.path.join(
             data_directory,
@@ -45,11 +49,14 @@ class DataLoader:
             self.length = int(np.ceil(self.length / 2.))
         self.split = split
         self.drop_last_batch = drop_last_batch
-        self.max_ind_range = max_ind_range
 
     def __iter__(self):
-        return iter(_batch_generator(self.data_filename, self.data_directory, self.days,
-                                     self.batch_size, self.split, self.drop_last_batch, self.max_ind_range))
+        return iter(
+            _batch_generator(
+                self.data_filename, self.data_directory, self.days,
+                self.batch_size, self.split, self.drop_last_batch, self.max_ind_range
+            )
+        )
 
     def __len__(self):
         if self.drop_last_batch:
@@ -58,7 +65,31 @@ class DataLoader:
             return math.ceil(self.length / self.batch_size)
 
 
-def _batch_generator(data_filename, data_directory, days, batch_size, split, drop_last, max_ind_range):
+def _transform_features(
+        x_int_batch, x_cat_batch, y_batch, max_ind_range, flag_input_torch_tensor=False
+):
+    if max_ind_range > 0:
+        x_cat_batch = x_cat_batch % max_ind_range
+
+    if flag_input_torch_tensor:
+        x_int_batch = torch.log(x_int_batch.clone().detach().type(torch.float) + 1)
+        x_cat_batch = x_cat_batch.clone().detach().type(torch.long)
+        y_batch = y_batch.clone().detach().type(torch.float32).view(-1, 1)
+    else:
+        x_int_batch = torch.log(torch.tensor(x_int_batch, dtype=torch.float) + 1)
+        x_cat_batch = torch.tensor(x_cat_batch, dtype=torch.long)
+        y_batch = torch.tensor(y_batch, dtype=torch.float32).view(-1, 1)
+
+    batch_size = x_cat_batch.shape[0]
+    feature_count = x_cat_batch.shape[1]
+    lS_o = torch.arange(batch_size).reshape(1, -1).repeat(feature_count, 1)
+
+    return x_int_batch, lS_o, x_cat_batch.t(), y_batch.view(-1, 1)
+
+
+def _batch_generator(
+        data_filename, data_directory, days, batch_size, split, drop_last, max_ind_range
+):
     previous_file = None
     for day in days:
         filepath = os.path.join(
@@ -105,7 +136,6 @@ def _batch_generator(data_filename, data_directory, days, batch_size, split, dro
                 y_batch = np.concatenate([previous_file['y'], y_batch], axis=0)
                 previous_file = None
 
-
             if x_int_batch.shape[0] != batch_size:
                 raise ValueError('should not happen')
 
@@ -134,22 +164,12 @@ def _batch_generator(data_filename, data_directory, days, batch_size, split, dro
                 }
 
     if not drop_last:
-        yield _transform_features(previous_file['x_int'],
-                                  previous_file['x_cat'],
-                                  previous_file['y'], max_ind_range)
-
-
-def _transform_features(x_int_batch, x_cat_batch, y_batch, max_ind_range):
-    if max_ind_range > 0: x_cat_batch = x_cat_batch % max_ind_range
-    x_int_batch = torch.log(torch.tensor(x_int_batch, dtype=torch.float) + 1)
-    x_cat_batch = torch.tensor(x_cat_batch, dtype=torch.long)
-    y_batch = torch.tensor(y_batch, dtype=torch.float32).view(-1, 1)
-
-    batch_size = x_cat_batch.shape[0]
-    feature_count = x_cat_batch.shape[1]
-    lS_o = torch.arange(batch_size).reshape(1, -1).repeat(feature_count, 1)
-
-    return x_int_batch, lS_o, x_cat_batch.t(), y_batch.view(-1, 1)
+        yield _transform_features(
+            previous_file['x_int'],
+            previous_file['x_cat'],
+            previous_file['y'],
+            max_ind_range
+        )
 
 
 def _test():
@@ -172,5 +192,171 @@ def _test():
         )
 
 
+class CriteoBinDataset(Dataset):
+    """Binary version of criteo dataset."""
+
+    def __init__(self, data_file, counts_file,
+                 batch_size=1, max_ind_range=-1, bytes_per_feature=4):
+        # dataset
+        self.tar_fea = 1   # single target
+        self.den_fea = 13  # 13 dense  features
+        self.spa_fea = 26  # 26 sparse features
+        self.tad_fea = self.tar_fea + self.den_fea
+        self.tot_fea = self.tad_fea + self.spa_fea
+
+        self.batch_size = batch_size
+        self.max_ind_range = max_ind_range
+        self.bytes_per_entry = (bytes_per_feature * self.tot_fea * batch_size)
+
+        self.num_entries = math.ceil(os.path.getsize(data_file) / self.bytes_per_entry)
+
+        print('data file:', data_file, 'number of batches:', self.num_entries)
+        self.file = open(data_file, 'rb')
+
+        with np.load(counts_file) as data:
+            self.counts = data["counts"]
+
+        # hardcoded for now
+        self.m_den = 13
+
+    def __len__(self):
+        return self.num_entries
+
+    def __getitem__(self, idx):
+        self.file.seek(idx * self.bytes_per_entry, 0)
+        raw_data = self.file.read(self.bytes_per_entry)
+        array = np.frombuffer(raw_data, dtype=np.int32)
+        tensor = torch.from_numpy(array).view((-1, self.tot_fea))
+
+        return _transform_features(x_int_batch=tensor[:, 1:14],
+                                   x_cat_batch=tensor[:, 14:],
+                                   y_batch=tensor[:, 0],
+                                   max_ind_range=self.max_ind_range,
+                                   flag_input_torch_tensor=True)
+
+
+def numpy_to_binary(input_files, output_file_path, split='train'):
+    """Convert the data to a binary format to be read with CriteoBinDataset."""
+
+    # WARNING - both categorical and numerical data must fit into int32 for
+    # the following code to work correctly
+
+    with open(output_file_path, 'wb') as output_file:
+        if split == 'train':
+            for input_file in input_files:
+                print('Processing file: ', input_file)
+
+                np_data = np.load(input_file)
+                np_data = np.concatenate([np_data['y'].reshape(-1, 1),
+                                          np_data['X_int'],
+                                          np_data['X_cat']], axis=1)
+                np_data = np_data.astype(np.int32)
+
+                output_file.write(np_data.tobytes())
+        else:
+            assert len(input_files) == 1
+            np_data = np.load(input_files[0])
+            np_data = np.concatenate([np_data['y'].reshape(-1, 1),
+                                      np_data['X_int'],
+                                      np_data['X_cat']], axis=1)
+            np_data = np_data.astype(np.int32)
+
+            samples_in_file = np_data.shape[0]
+            midpoint = int(np.ceil(samples_in_file / 2.))
+            if split == "test":
+                begin = 0
+                end = midpoint
+            elif split == "val":
+                begin = midpoint
+                end = samples_in_file
+            else:
+                raise ValueError('Unknown split value: ', split)
+
+            output_file.write(np_data[begin:end].tobytes())
+
+
+def _preprocess(args):
+    train_files = ['{}_{}_reordered.npz'.format(args.input_data_prefix, day) for
+                   day in range(0, 23)]
+
+    test_valid_file = args.input_data_prefix + '_23_reordered.npz'
+
+    os.makedirs(args.output_directory, exist_ok=True)
+    for split in ['train', 'val', 'test']:
+        print('Running preprocessing for split =', split)
+
+        output_file = os.path.join(args.output_directory,
+                                   '{}_data.bin'.format(split))
+
+        input_files = train_files if split == 'train' else [test_valid_file]
+        numpy_to_binary(input_files=input_files,
+                        output_file_path=output_file,
+                        split=split)
+
+
+def _test_bin():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--output_directory', required=True)
+    parser.add_argument('--input_data_prefix', required=True)
+    parser.add_argument('--split', choices=['train', 'test', 'val'],
+                        required=True)
+    args = parser.parse_args()
+
+    # _preprocess(args)
+
+    binary_data_file = os.path.join(args.output_directory,
+                                    '{}_data.bin'.format(args.split))
+
+    counts_file = os.path.join(args.output_directory, 'day_fea_count.npz')
+    dataset_binary = CriteoBinDataset(data_file=binary_data_file,
+                                            counts_file=counts_file,
+                                            batch_size=2048,)
+    from dlrm_data_pytorch import CriteoDataset, collate_wrapper_criteo
+
+    binary_loader = torch.utils.data.DataLoader(
+        dataset_binary,
+        batch_size=None,
+        shuffle=False,
+        num_workers=0,
+        collate_fn=None,
+        pin_memory=False,
+        drop_last=False,
+    )
+
+    original_dataset = CriteoDataset(
+        dataset='terabyte',
+        max_ind_range=-1,
+        sub_sample_rate=1,
+        randomize=True,
+        split=args.split,
+        raw_path=args.input_data_prefix,
+        pro_data='dummy_string',
+        memory_map=True
+    )
+
+    original_loader = torch.utils.data.DataLoader(
+        original_dataset,
+        batch_size=2048,
+        shuffle=False,
+        num_workers=0,
+        collate_fn=collate_wrapper_criteo,
+        pin_memory=False,
+        drop_last=False,
+    )
+
+    assert len(dataset_binary) == len(original_loader)
+    for i, (old_batch, new_batch) in tqdm(enumerate(zip(original_loader,
+                                                        binary_loader)),
+                                          total=len(dataset_binary)):
+
+        for j in range(len(new_batch)):
+            if not np.array_equal(old_batch[j], new_batch[j]):
+                raise ValueError('FAILED: Datasets not equal')
+        if i > len(dataset_binary):
+            break
+    print('PASSED')
+
+
 if __name__ == '__main__':
     _test()
+    _test_bin

--- a/dlrm_data_caffe2.py
+++ b/dlrm_data_caffe2.py
@@ -95,7 +95,10 @@ def read_dataset(
         print("Sparse features = %d, Dense features = %d" % (n_emb, m_den))
 
         # adjust parameters
-        def assemble_samples(X_cat, X_int, y, print_message):
+        def assemble_samples(X_cat, X_int, y, max_ind_range, print_message):
+            if max_ind_range > 0:
+                X_cat = X_cat % max_ind_range
+
             nsamples = len(y)
             data_size = nsamples
             # using floor is equivalent to dropping last mini-batch (drop_last = True)
@@ -155,12 +158,12 @@ def read_dataset(
 
         # adjust training data
         (nbatches, lX, lS_lengths, lS_indices, lT) = assemble_samples(
-            X_cat_train, X_int_train, y_train, "Training data"
+            X_cat_train, X_int_train, y_train, max_ind_range, "Training data"
         )
 
         # adjust testing data
         (nbatches_t, lX_t, lS_lengths_t, lS_indices_t, lT_t) = assemble_samples(
-            X_cat_test, X_int_test, y_test, "Testing data"
+            X_cat_test, X_int_test, y_test, max_ind_range, "Testing data"
         )
     #end if memory_map
 

--- a/dlrm_data_pytorch.py
+++ b/dlrm_data_pytorch.py
@@ -32,7 +32,7 @@ from numpy import random as ra
 
 # pytorch
 import torch
-from torch.utils.data import Dataset
+from torch.utils.data import Dataset, RandomSampler
 
 import data_loader_terabyte
 
@@ -336,9 +336,8 @@ def collate_wrapper_criteo(list_of_tuples):
     return X_int, torch.stack(lS_o), torch.stack(lS_i), T
 
 
-def make_criteo_data_and_loaders(args):
-
-    train_data = CriteoDataset(
+def ensure_dataset_preprocessed(args, d_path):
+    _ = CriteoDataset(
         args.data_set,
         args.max_ind_range,
         args.data_sub_sample_rate,
@@ -349,7 +348,7 @@ def make_criteo_data_and_loaders(args):
         args.memory_map
     )
 
-    test_data = CriteoDataset(
+    _ = CriteoDataset(
         args.data_set,
         args.max_ind_range,
         args.data_sub_sample_rate,
@@ -360,29 +359,143 @@ def make_criteo_data_and_loaders(args):
         args.memory_map
     )
 
+    for split in ['train', 'val', 'test']:
+        print('Running preprocessing for split =', split)
+
+        train_files = ['{}_{}_reordered.npz'.format(args.raw_data_file, day)
+                       for
+                       day in range(0, 23)]
+
+        test_valid_file = args.raw_data_file + '_23_reordered.npz'
+
+        output_file = d_path + '_{}.bin'.format(split)
+
+        input_files = train_files if split == 'train' else [test_valid_file]
+        data_loader_terabyte.numpy_to_binary(input_files=input_files,
+                                             output_file_path=output_file,
+                                             split=split)
+
+
+def make_criteo_data_and_loaders(args):
+
     if args.mlperf_logging and args.memory_map and args.data_set == "terabyte":
         # more efficient for larger batches
         data_directory = path.dirname(args.raw_data_file)
-        data_filename = args.raw_data_file.split("/")[-1]
 
-        train_loader = data_loader_terabyte.DataLoader(
-            data_directory=data_directory,
-            data_filename=data_filename,
-            days=list(range(23)),
-            batch_size=args.mini_batch_size,
-            max_ind_range = args.max_ind_range,
-            split="train"
-        )
+        if args.mlperf_bin_loader:
+            lstr = args.processed_data_file.split("/")
+            d_path = "/".join(lstr[0:-1]) + "/" + lstr[-1].split(".")[0]
+            train_file = d_path + "_train.bin"
+            test_file = d_path + "_test.bin"
+            # val_file = d_path + "_val.bin"
+            counts_file = args.raw_data_file + '_fea_count.npz'
 
-        test_loader = data_loader_terabyte.DataLoader(
-            data_directory=data_directory,
-            data_filename=data_filename,
-            days=[23],
-            batch_size=args.test_mini_batch_size,
-            max_ind_range = args.max_ind_range,
-            split="test"
-        )
+            if any(not path.exists(p) for p in [train_file,
+                                                test_file,
+                                                counts_file]):
+                ensure_dataset_preprocessed(args, d_path)
+
+            train_data = data_loader_terabyte.CriteoBinDataset(
+                data_file=train_file,
+                counts_file=counts_file,
+                batch_size=args.mini_batch_size,
+                max_ind_range=args.max_ind_range
+            )
+
+            train_loader = torch.utils.data.DataLoader(
+                train_data,
+                batch_size=None,
+                batch_sampler=None,
+                shuffle=False,
+                num_workers=0,
+                collate_fn=None,
+                pin_memory=False,
+                drop_last=False,
+                sampler=RandomSampler(train_data) if args.mlperf_bin_shuffle else None
+            )
+
+            test_data = data_loader_terabyte.CriteoBinDataset(
+                data_file=test_file,
+                counts_file=counts_file,
+                batch_size=args.test_mini_batch_size,
+                max_ind_range=args.max_ind_range
+            )
+
+            test_loader = torch.utils.data.DataLoader(
+                test_data,
+                batch_size=None,
+                batch_sampler=None,
+                shuffle=False,
+                num_workers=0,
+                collate_fn=None,
+                pin_memory=False,
+                drop_last=False,
+            )
+        else:
+            data_filename = args.raw_data_file.split("/")[-1]
+
+            train_data = CriteoDataset(
+                args.data_set,
+                args.max_ind_range,
+                args.data_sub_sample_rate,
+                args.data_randomize,
+                "train",
+                args.raw_data_file,
+                args.processed_data_file,
+                args.memory_map
+            )
+
+            test_data = CriteoDataset(
+                args.data_set,
+                args.max_ind_range,
+                args.data_sub_sample_rate,
+                args.data_randomize,
+                "test",
+                args.raw_data_file,
+                args.processed_data_file,
+                args.memory_map
+            )
+
+            train_loader = data_loader_terabyte.DataLoader(
+                data_directory=data_directory,
+                data_filename=data_filename,
+                days=list(range(23)),
+                batch_size=args.mini_batch_size,
+                max_ind_range=args.max_ind_range,
+                split="train"
+            )
+
+            test_loader = data_loader_terabyte.DataLoader(
+                data_directory=data_directory,
+                data_filename=data_filename,
+                days=[23],
+                batch_size=args.test_mini_batch_size,
+                max_ind_range=args.max_ind_range,
+                split="test"
+            )
     else:
+        train_data = CriteoDataset(
+            args.data_set,
+            args.max_ind_range,
+            args.data_sub_sample_rate,
+            args.data_randomize,
+            "train",
+            args.raw_data_file,
+            args.processed_data_file,
+            args.memory_map
+        )
+
+        test_data = CriteoDataset(
+            args.data_set,
+            args.max_ind_range,
+            args.data_sub_sample_rate,
+            args.data_randomize,
+            "test",
+            args.raw_data_file,
+            args.processed_data_file,
+            args.memory_map
+        )
+
         train_loader = torch.utils.data.DataLoader(
             train_data,
             batch_size=args.mini_batch_size,
@@ -392,6 +505,7 @@ def make_criteo_data_and_loaders(args):
             pin_memory=False,
             drop_last=False,  # True
         )
+
         test_loader = torch.utils.data.DataLoader(
             test_data,
             batch_size=args.test_mini_batch_size,
@@ -541,7 +655,6 @@ def make_random_data_and_loader(args, ln_emb, m_den):
         drop_last=False,  # True
     )
     return train_data, train_loader
-
 
 
 def generate_random_data(

--- a/dlrm_s_caffe2.py
+++ b/dlrm_s_caffe2.py
@@ -58,12 +58,14 @@ import functools
 # others
 import operator
 import time
+import copy
 
 # data generation
 import dlrm_data_caffe2 as dc
 
 # numpy
 import numpy as np
+import sklearn.metrics
 
 # onnx
 # The onnx import causes deprecation warnings every time workers
@@ -474,6 +476,7 @@ class DLRM_Net(object):
         sigmoid_top=-1,
         save_onnx=False,
         model=None,
+        test_net=None,
         tag=None,
         ndevices=-1,
         forward_ops=True,
@@ -493,11 +496,13 @@ class DLRM_Net(object):
             workspace.GlobalInit(global_init_opt)
             self.set_tags()
             self.model = model_helper.ModelHelper(name="DLRM", init_params=True)
+            self.test_net = None
         else:
             # WARNING: assume that workspace and tags have been initialized elsewhere
             self.set_tags(tag[0], tag[1], tag[2], tag[3], tag[4], tag[5], tag[6],
                           tag[7], tag[8], tag[9])
             self.model = model
+            self.test_net = test_net
 
         # save arguments
         self.m_spa = m_spa
@@ -609,8 +614,10 @@ class DLRM_Net(object):
             # We could use direct calls to self.model functions above to avoid it
             workspace.RunNetOnce(self.model.param_init_net)
             workspace.CreateNet(self.model.net)
+            if self.test_net is not None:
+                workspace.CreateNet(self.test_net)
 
-    def run(self, X, S_lengths, S_indices, T, enable_prof=False):
+    def run(self, X, S_lengths, S_indices, T, test_net=False, enable_prof=False):
         # feed input data to blobs
         # dense features
         self.FeedBlobWrapper(self.tdin, X, split=True)
@@ -632,10 +639,13 @@ class DLRM_Net(object):
         if T is not None:
             self.FeedBlobWrapper(self.ttar, T, split=True)
             # execute compute graph
-            if enable_prof:
-                workspace.C.benchmark_net(self.model.net.Name(), 0, 1, True)
+            if test_net:
+                workspace.RunNet(self.test_net)
             else:
-                workspace.RunNet(self.model.net)
+                if enable_prof:
+                    workspace.C.benchmark_net(self.model.net.Name(), 0, 1, True)
+                else:
+                    workspace.RunNet(self.model.net)
         # debug prints
         # print("intermediate")
         # print(self.FetchBlobWrapper(self.bot_l[-1]))
@@ -790,6 +800,71 @@ class DLRM_Net(object):
             print(self.FetchBlobWrapper(l))
 
 
+def define_metrics():
+    metrics = {
+        'loss': lambda y_true, y_score:
+        sklearn.metrics.log_loss(
+            y_true=y_true,
+            y_pred=y_score,
+            labels=[0,1]),
+        'recall': lambda y_true, y_score:
+        sklearn.metrics.recall_score(
+            y_true=y_true,
+            y_pred=np.round(y_score)
+        ),
+        'precision': lambda y_true, y_score:
+        sklearn.metrics.precision_score(
+            y_true=y_true,
+            y_pred=np.round(y_score)
+        ),
+        'f1': lambda y_true, y_score:
+        sklearn.metrics.f1_score(
+            y_true=y_true,
+            y_pred=np.round(y_score)
+        ),
+        'ap': sklearn.metrics.average_precision_score,
+        'roc_auc': sklearn.metrics.roc_auc_score,
+        'accuracy': lambda y_true, y_score:
+        sklearn.metrics.accuracy_score(
+            y_true=y_true,
+            y_pred=np.round(y_score)
+        ),
+        # 'pre_curve' : sklearn.metrics.precision_recall_curve,
+        # 'roc_curve' :  sklearn.metrics.roc_curve,
+    }
+    return metrics
+
+
+def calculate_metrics(targets, scores):
+    scores = np.concatenate(scores, axis=0)
+    targets = np.concatenate(targets, axis=0)
+
+    metrics = define_metrics()
+
+    # print("Compute time for validation metric : ", end="")
+    # first_it = True
+    validation_results = {}
+    for metric_name, metric_function in metrics.items():
+        # if first_it:
+        #     first_it = False
+        # else:
+        #     print(", ", end="")
+        # metric_compute_start = time_wrap(False)
+        try:
+            validation_results[metric_name] = metric_function(
+                targets,
+                scores
+            )
+        except Exception as error :
+            validation_results[metric_name] = -1
+            print("{} in calculating {}".format(error, metric_name))
+        # metric_compute_end = time_wrap(False)
+        # met_time = metric_compute_end - metric_compute_start
+        # print("{} {:.4f}".format(metric_name, 1000 * (met_time)),
+        #      end="")
+    # print(" ms")
+    return validation_results
+
 if __name__ == "__main__":
     ### import packages ###
     import sys
@@ -843,10 +918,17 @@ if __name__ == "__main__":
     parser.add_argument("--use-gpu", action="store_true", default=False)
     # debugging and profiling
     parser.add_argument("--print-freq", type=int, default=1)
+    parser.add_argument("--test-freq", type=int, default=-1)
     parser.add_argument("--print-time", action="store_true", default=False)
     parser.add_argument("--debug-mode", action="store_true", default=False)
     parser.add_argument("--enable-profiling", action="store_true", default=False)
     parser.add_argument("--plot-compute-graph", action="store_true", default=False)
+    # mlperf logging (disables other output and stops early)
+    parser.add_argument("--mlperf-logging", action="store_true", default=False)
+    # stop at target accuracy Kaggle 0.789, Terabyte (sub-sampled=0.875) 0.8107
+    parser.add_argument("--mlperf-acc-threshold", type=float, default=0.0)
+    # stop at target AUC Terabyte (no subsampling) 0.8025
+    parser.add_argument("--mlperf-auc-threshold", type=float, default=0.0)
     args = parser.parse_args()
 
     ### some basic setup ###
@@ -875,7 +957,10 @@ if __name__ == "__main__":
         )
         # enforce maximum limit on number of vectors per embedding
         if args.max_ind_range > 0:
-            ln_emb = np.array(list(map(lambda x: x % args.max_ind_range, ln_emb)))
+            ln_emb = np.array(list(map(
+                lambda x: x if x < args.max_ind_range else args.max_ind_range,
+                ln_emb
+            )))
         ln_bot[0] = m_den
     else:
         # input and target at random
@@ -1002,6 +1087,9 @@ if __name__ == "__main__":
                 sys.exit("ERROR: --loss-function=" + args.loss_function
                          + " is not supported")
 
+            # define test net (as train net without gradients)
+            dlrm.test_net = core.Net(copy.deepcopy(dlrm.model.net.Proto()))
+
             # specify the optimizer algorithm
             dlrm.sgd_optimizer(
                 args.learning_rate, sync_dense_params=args.sync_dense_params
@@ -1010,7 +1098,8 @@ if __name__ == "__main__":
     dlrm.create(lX[0], lS_l[0], lS_i[0], lT[0])
 
     ### main loop ###
-    print("time/loss/accuracy (if enabled):")
+    best_gA_test = 0
+    best_auc_test = 0
     total_time = 0
     total_loss = 0
     total_accu = 0
@@ -1018,6 +1107,7 @@ if __name__ == "__main__":
     total_samp = 0
     k = 0
 
+    print("time/loss/accuracy (if enabled):")
     while k < args.nepochs:
         j = 0
         while j < nbatches:
@@ -1029,7 +1119,6 @@ if __name__ == "__main__":
             print(lS_i[j])
             print(lT[j].astype(np.float32))
             '''
-
             # forward and backward pass, where the latter runs only
             # when gradients and loss have been added to the net
             time1 = time.time()
@@ -1054,8 +1143,13 @@ if __name__ == "__main__":
             total_samp += mbs
 
             # print time, loss and accuracy
-            print_tl = ((j + 1) % args.print_freq == 0) or (j + 1 == nbatches)
-            if print_tl:
+            should_print = ((j + 1) % args.print_freq == 0) or (j + 1 == nbatches)
+            should_test = (
+                (args.test_freq > 0)
+                and (args.data_generation == "dataset")
+                and (((j + 1) % args.test_freq == 0) or (j + 1 == nbatches))
+            )
+            if should_print or should_test:
                 gT = 1000. * total_time / total_iter if args.print_time else -1
                 total_time = 0
 
@@ -1078,7 +1172,108 @@ if __name__ == "__main__":
                 # print(Z)
                 # print(T)
 
-            j += 1  # nbatches
+                # testing
+                if should_test and not args.inference_only:
+                    # don't measure training iter time in a test iteration
+                    if args.mlperf_logging:
+                        previous_iteration_time = None
+
+                    test_accu = 0
+                    test_loss = 0
+                    test_samp = 0
+
+                    if args.mlperf_logging:
+                        scores = []
+                        targets = []
+
+                    for i in range(nbatches_test):
+                        # early exit if nbatches was set by the user and was exceeded
+                        if nbatches > 0 and i >= nbatches:
+                            break
+
+                        # forward pass
+                        dlrm.run(lX_test[i], lS_l_test[i], lS_i_test[i], lT_test[i], test_net=True)
+                        Z_test = dlrm.get_output()
+                        T_test = lT_test[i]
+
+                        if args.mlperf_logging:
+                            scores.append(Z_test)
+                            targets.append(T_test)
+                        else:
+                            # compte loss and accuracy
+                            L_test = dlrm.get_loss()
+                            mbs_test = T_test.shape[0]  # = mini_batch_size except last
+                            A_test = np.sum((np.round(Z_test, 0) == T_test).astype(np.uint8))
+                            test_accu += A_test
+                            test_loss += L_test * mbs_test
+                            test_samp += mbs_test
+
+                    # compute metrics (after test loop has finished)
+                    if args.mlperf_logging:
+                        validation_results = calculate_metrics(targets, scores)
+                        gA_test = validation_results['accuracy']
+                        gL_test = validation_results['loss']
+                    else:
+                        gA_test = test_accu / test_samp
+                        gL_test = test_loss / test_samp
+
+                    # print metrics
+                    is_best = gA_test > best_gA_test
+                    if is_best:
+                        best_gA_test = gA_test
+
+                    if args.mlperf_logging:
+                        is_best = validation_results['roc_auc'] > best_auc_test
+                        if is_best:
+                            best_auc_test = validation_results['roc_auc']
+
+                        print(
+                            "Testing at - {}/{} of epoch {},".format(j + 1, nbatches, k)
+                            + " loss {:.6f}, recall {:.4f}, precision {:.4f},".format(
+                                validation_results['loss'],
+                                validation_results['recall'],
+                                validation_results['precision']
+                            )
+                            + " f1 {:.4f}, ap {:.4f},".format(
+                                validation_results['f1'],
+                                validation_results['ap'],
+                            )
+                            + " auc {:.4f}, best auc {:.4f},".format(
+                                validation_results['roc_auc'],
+                                best_auc_test
+                            )
+                            + " accuracy {:3.3f} %, best accuracy {:3.3f} %".format(
+                                validation_results['accuracy'] * 100,
+                                best_gA_test * 100
+                            )
+                        )
+                    else:
+                        print(
+                            "Testing at - {}/{} of epoch {},".format(j + 1, nbatches, 0)
+                            + " loss {:.6f}, accuracy {:3.3f} %, best {:3.3f} %".format(
+                                gL_test, gA_test * 100, best_gA_test * 100
+                            )
+                        )
+
+                    # check thresholds
+                    if (args.mlperf_logging
+                        and (args.mlperf_acc_threshold > 0)
+                        and (best_gA_test > args.mlperf_acc_threshold)):
+                        print("MLPerf testing accuracy threshold "
+                              + str(args.mlperf_acc_threshold)
+                              + " reached, stop training")
+                        break
+
+                    if (args.mlperf_logging
+                        and (args.mlperf_auc_threshold > 0)
+                        and (best_auc_test > args.mlperf_auc_threshold)):
+                        print("MLPerf testing auc threshold "
+                              + str(args.mlperf_auc_threshold)
+                              + " reached, stop training")
+                        break
+
+
+            j += 1 # nbatches
         k += 1  # nepochs
 
     # test prints

--- a/dlrm_s_pytorch.py
+++ b/dlrm_s_pytorch.py
@@ -623,10 +623,10 @@ if __name__ == "__main__":
     parser.add_argument("--mlperf-bin-shuffle", action='store_true', default=False)
     args = parser.parse_args()
 
+    ext_dist.init_distributed(backend=args.dist_backend)
+
     if args.mlperf_logging:
         print('command line args: ', json.dumps(vars(args)))
-
-    ext_dist.init_distributed(backend=args.dist_backend)
 
     ### some basic setup ###
     np.random.seed(args.numpy_rand_seed)

--- a/dlrm_s_pytorch.py
+++ b/dlrm_s_pytorch.py
@@ -1027,6 +1027,11 @@ if __name__ == "__main__":
                 print([S_i.detach().cpu().numpy().tolist() for S_i in lS_i])
                 print(T.detach().cpu().numpy())
                 '''
+                # Skip the batch if batch size not multiple of total ranks
+                if ext_dist.my_size > 1 and X.size(0) % ext_dist.my_size != 0:
+                    print("Warning: Skiping the batch %d with size %d" % (j, X.size(0)))
+                    continue
+
 
                 # forward pass
                 Z = dlrm_wrap(X, lS_o, lS_i, use_gpu, device)
@@ -1120,6 +1125,11 @@ if __name__ == "__main__":
                         # early exit if nbatches was set by the user and was exceeded
                         if nbatches > 0 and i >= nbatches:
                             break
+
+                        # Skip the batch if batch size not multiple of total ranks
+                        if ext_dist.my_size > 1 and X_test.size(0) % ext_dist.my_size != 0:
+                            print("Warning: Skiping the batch %d with size %d" % (i, X_test.size(0)))
+                            continue
 
                         t1_test = time_wrap(use_gpu)
 

--- a/dlrm_s_pytorch.py
+++ b/dlrm_s_pytorch.py
@@ -537,6 +537,7 @@ class DLRM_Net(nn.Module):
 if __name__ == "__main__":
     ### import packages ###
     import sys
+    import os
     import argparse
 
     ### parse arguments ###
@@ -609,6 +610,7 @@ if __name__ == "__main__":
     parser.add_argument("--enable-profiling", action="store_true", default=False)
     parser.add_argument("--plot-compute-graph", action="store_true", default=False)
     # store/load model
+    parser.add_argument("--out-dir", type=str, default=".")
     parser.add_argument("--save-model", type=str, default="")
     parser.add_argument("--load-model", type=str, default="")
     # mlperf logging (disables other output and stops early)
@@ -1292,9 +1294,10 @@ if __name__ == "__main__":
 
             k += 1  # nepochs
 
-    file_prefix = "dlrm_s_pytorch_r%d" % ext_dist.my_rank
+    file_prefix = "%s/dlrm_s_pytorch_r%d" % (args.out_dir, ext_dist.my_rank)
     # profiling
     if args.enable_profiling:
+        os.makedirs(args.out_dir, exist_ok=True)
         with open("%s.prof" % file_prefix, "w") as prof_f:
             prof_f.write(prof.key_averages().table(sort_by="cpu_time_total"))
             prof.export_chrome_trace("./%s.json" % file_prefix)
@@ -1307,6 +1310,7 @@ if __name__ == "__main__":
             + " visualization. Then, uncomment its import above as well as"
             + " three lines below and run the code again."
         )
+        # os.makedirs(args.out_dir, exist_ok=True)
         # V = Z.mean() if args.inference_only else E
         # dot = make_dot(V, params=dict(dlrm.named_parameters()))
         # dot.render('%s_graph' % file_prefix) # write .pdf file
@@ -1319,6 +1323,7 @@ if __name__ == "__main__":
 
     # export the model in onnx
     if args.save_onnx:
+        os.makedirs(args.out_dir, exist_ok=True)
         with open("%s.onnx" % file_prefix, "w+b") as dlrm_pytorch_onnx_file:
             (X, lS_o, lS_i, _) = train_data[0]  # get first batch of elements
             torch.onnx._export(

--- a/dlrm_s_pytorch.py
+++ b/dlrm_s_pytorch.py
@@ -854,8 +854,13 @@ if __name__ == "__main__":
             dlrm.emb_l = dlrm.create_emb(m_spa, ln_emb)
     
     if ext_dist.my_size > 1:
-        dlrm.bot_l = ext_dist.DDP(dlrm.bot_l)
-        dlrm.top_l = ext_dist. DDP(dlrm.top_l)
+        if use_gpu:
+            device_ids = [ext_dist.my_local_rank]
+            dlrm.bot_l = ext_dist.DDP(dlrm.bot_l, device_ids=device_ids)
+            dlrm.top_l = ext_dist.DDP(dlrm.top_l, device_ids=device_ids)
+        else:
+            dlrm.bot_l = ext_dist.DDP(dlrm.bot_l)
+            dlrm.top_l = ext_dist.DDP(dlrm.top_l)
 
     # specify the loss function
     if args.loss_function == "mse":

--- a/extend_distributed.py
+++ b/extend_distributed.py
@@ -1,4 +1,5 @@
 import os
+import builtins
 import torch
 from torch.autograd import Function
 from torch.nn.parallel import DistributedDataParallel as DDP
@@ -379,3 +380,16 @@ def all_gather(input, lengths, dim=0):
 def barrier():
     if my_size > 1:
         dist.barrier()
+
+# Override builtin print function to print only from rank 0
+orig_print = builtins.print
+
+def rank0_print(*args, **kwargs):
+    if my_rank <= 0 or kwargs.get('print_all', False):
+        orig_print(*args, **kwargs)
+
+builtins.print = rank0_print
+
+# Allow printing from all rank with explicit print_all
+def print_all(*args, **kwargs):
+    orig_print(*args, **kwargs)


### PR DESCRIPTION
- Align distributed embedding table initialization with single rank initialization
- Allow selecting alltoall impl using env DLRM_ALLTOALL_IMPL
- Skip batch when minibatch is not divisible by world size to avoid runtime error
- Add support for using Intel oneCCL custom backend
- Add support to specify output directory for profiler log files
- Override print function to print from rank 0 and provide print_all function to print from all the ranks
- Fix DDP wrapper when using GPUs
- Improve alltoall support check and non-mpi backend init