### PR TITLE
Mixd Bugfixes

### DIFF
--- a/dlrm_s_pytorch.py
+++ b/dlrm_s_pytorch.py
@@ -179,9 +179,9 @@ class DLRM_Net(nn.Module):
             if self.qr_flag and n > self.qr_threshold:
                 EE = QREmbeddingBag(n, m, self.qr_collisions,
                     operation=self.qr_operation, mode="sum", sparse=True)
-            elif self.md_flag and n > self.md_threshold:
-                _m = m[i]
+            elif self.md_flag:
                 base = max(m)
+                _m = m[i] if n > self.md_threshold else base
                 EE = PrEmbeddingBag(n, _m, base)
                 # use np initialization as below for consistency...
                 W = np.random.uniform(

--- a/tricks/md_embedding_bag.py
+++ b/tricks/md_embedding_bag.py
@@ -41,7 +41,6 @@ def md_solver(n, alpha, d0=None, B=None, round_dim=True, k=None):
 
 
 def alpha_power_rule(n, alpha, d0=None, B=None):
-
     if d0 is not None:
         lamb = d0 * (n[0].type(torch.float) ** alpha)
     elif B is not None:

--- a/tricks/md_embedding_bag.py
+++ b/tricks/md_embedding_bag.py
@@ -34,10 +34,14 @@ def md_solver(n, alpha, d0=None, B=None, round_dim=True, k=None):
     d = alpha_power_rule(n.type(torch.float) / k, alpha, d0=d0, B=B)
     if round_dim:
         d = pow_2_round(d)
-    return d
+    undo_sort = [0] * len(indices)
+    for i, v in enumerate(indices):
+        undo_sort[v] = i
+    return d[undo_sort]
 
 
 def alpha_power_rule(n, alpha, d0=None, B=None):
+
     if d0 is not None:
         lamb = d0 * (n[0].type(torch.float) ** alpha)
     elif B is not None:


### PR DESCRIPTION
2 minor bugfixes for the mixd compression trick:

1 - Fix a runtime crash when `md_flag` is set and `n < md_threshold` in `dlrm_s_pytorch.py`
2 - Fix a bug when the embedding tables are not sorted by # of rows in `tricks/md_embedding_bag.py`

