### PR TITLE
Change the source and version of the MLPerf logging library

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ pydot
 torch
 torchviz
 scikit-learn
--e git://github.com/tgrel/logging@ba1ec1d#egg=logging
+-e git://github.com/mlperf/logging@0.7.0-rc2#egg=logging


### PR DESCRIPTION
Move the source repository of the logging library to the official mlperf/logging package. Use the Release-Candidate-2 tag