### PR TITLE
Parallelizing the pre-processing of the dataset.

### DIFF
--- a/data_utils.py
+++ b/data_utils.py
@@ -145,12 +145,7 @@ def processCriteoAdData(d_path, d_file, npzfile, i, convertDicts, pre_comp_count
             X_cat_t = np.zeros(data["X_cat_t"].shape)
             for j in range(26):
                 for k, x in enumerate(data["X_cat_t"][j, :]):
-                    #print("1", X_cat_t[j, k])
-                    #print("2.0 j:", j)
-                    #print("2.1 x:", x)
-                    #print("2", convertDicts[j][x])
                     X_cat_t[j, k] = convertDicts[j][x]
-                    #print("3 end")
             # continuous features
             X_int = data["X_int"]
             X_int[X_int < 0] = 0

--- a/dlrm_data_pytorch.py
+++ b/dlrm_data_pytorch.py
@@ -55,7 +55,8 @@ class CriteoDataset(Dataset):
             split="train",
             raw_path="",
             pro_data="",
-            memory_map=False
+            memory_map=False,
+            dataset_multiprocessing=False
     ):
         # dataset
         # tar_fea = 1   # single target
@@ -112,7 +113,8 @@ class CriteoDataset(Dataset):
                 split,
                 randomize,
                 dataset == "kaggle",
-                memory_map
+                memory_map,
+                dataset_multiprocessing
             )
 
         # get a number of samples per day
@@ -345,7 +347,8 @@ def ensure_dataset_preprocessed(args, d_path):
         "train",
         args.raw_data_file,
         args.processed_data_file,
-        args.memory_map
+        args.memory_map,
+        args.dataset_multiprocessing
     )
 
     _ = CriteoDataset(
@@ -356,7 +359,8 @@ def ensure_dataset_preprocessed(args, d_path):
         "test",
         args.raw_data_file,
         args.processed_data_file,
-        args.memory_map
+        args.memory_map,
+        args.dataset_multiprocessing
     )
 
     for split in ['train', 'val', 'test']:
@@ -442,7 +446,8 @@ def make_criteo_data_and_loaders(args):
                 "train",
                 args.raw_data_file,
                 args.processed_data_file,
-                args.memory_map
+                args.memory_map,
+                args.dataset_multiprocessing
             )
 
             test_data = CriteoDataset(
@@ -453,7 +458,8 @@ def make_criteo_data_and_loaders(args):
                 "test",
                 args.raw_data_file,
                 args.processed_data_file,
-                args.memory_map
+                args.memory_map,
+                args.dataset_multiprocessing
             )
 
             train_loader = data_loader_terabyte.DataLoader(
@@ -482,7 +488,8 @@ def make_criteo_data_and_loaders(args):
             "train",
             args.raw_data_file,
             args.processed_data_file,
-            args.memory_map
+            args.memory_map,
+            args.dataset_multiprocessing
         )
 
         test_data = CriteoDataset(
@@ -493,7 +500,8 @@ def make_criteo_data_and_loaders(args):
             "test",
             args.raw_data_file,
             args.processed_data_file,
-            args.memory_map
+            args.memory_map,
+            args.dataset_multiprocessing
         )
 
         train_loader = torch.utils.data.DataLoader(

--- a/dlrm_s_pytorch.py
+++ b/dlrm_s_pytorch.py
@@ -552,6 +552,11 @@ if __name__ == "__main__":
     parser.add_argument("--num-indices-per-lookup-fixed", type=bool, default=False)
     parser.add_argument("--num-workers", type=int, default=0)
     parser.add_argument("--memory-map", action="store_true", default=False)
+    parser.add_argument("--dataset-multiprocessing", action="store_true", default=False,
+                        help="The Kaggle dataset can be multiprocessed in an environment \
+                        with more than 7 CPU cores and more than 20 GB of memory. \n \
+                        The Terabyte dataset can be multiprocessed in an environment \
+                        with more than 24 CPU cores and more than 600 GB of memory.")
     # training
     parser.add_argument("--mini-batch-size", type=int, default=1)
     parser.add_argument("--nepochs", type=int, default=1)

--- a/dlrm_s_pytorch.py
+++ b/dlrm_s_pytorch.py
@@ -556,7 +556,7 @@ if __name__ == "__main__":
                         help="The Kaggle dataset can be multiprocessed in an environment \
                         with more than 7 CPU cores and more than 20 GB of memory. \n \
                         The Terabyte dataset can be multiprocessed in an environment \
-                        with more than 24 CPU cores and more than 600 GB of memory.")
+                        with more than 24 CPU cores and at least 1 TB of memory.")
     # training
     parser.add_argument("--mini-batch-size", type=int, default=1)
     parser.add_argument("--nepochs", type=int, default=1)


### PR DESCRIPTION
1. The current "process_one_file" function takes a long time using a single core.
This part of the pre-processing takes the longest time.
 　 
I modified it to enable parallelization in units of day files.
This parallelizing reduce the execution time of function dramatically.
In particular, using the Terabyte dataset can reduce the processing time from a few days to several hours.
 　 
ConvertDict, which interferes with parallelization, was handled as follows.
(1) Dictionary keys (convertDictDay) are created by date.
(2) To create convertDict, convertDictDay each created by parallelization is configured in order of the day.
 　 (The third commit reflects its modification.)

2. The second-longest part of the data pre-processing is "processCriteoAdData" function.
This parallelizing can also reduce the processing time of this part from a few days to several hours when using the Terabyte dataset.

3. Finally, added the '--dataset_multiprocessing' argument for use on resources available machines.
