### PR TITLE
Fix to read terabyte dataset in .gzip format 

### DIFF
--- a/data_utils.py
+++ b/data_utils.py
@@ -919,7 +919,7 @@ def getCriteoAdData(
             # missing and will be interpreted as 0).
             if path.exists(datafile):
                 print("Reading data from path=%s" % (datafile))
-                with gzipopen(str(datafile)) as f:
+                with open(str(datafile)) as f:
                     for _ in f:
                         total_count += 1
                 total_per_file.append(total_count)
@@ -954,7 +954,7 @@ def getCriteoAdData(
                     print("Reading data from path=%s" % (str(datafile_i)))
                     # file day_<number>
                     total_per_file_count = 0
-                    with open(str(datafile_i)) as f:
+                    with gzip.open(str(datafile_i)) as f:
                         for _ in f:
                             total_per_file_count += 1
                     total_per_file.append(total_per_file_count)

--- a/data_utils.py
+++ b/data_utils.py
@@ -43,6 +43,7 @@ from os import path
 # import io
 # from io import StringIO
 # import collections as coll
+import gzip
 
 import numpy as np
 
@@ -918,7 +919,7 @@ def getCriteoAdData(
             # missing and will be interpreted as 0).
             if path.exists(datafile):
                 print("Reading data from path=%s" % (datafile))
-                with open(str(datafile)) as f:
+                with gzipopen(str(datafile)) as f:
                     for _ in f:
                         total_count += 1
                 total_per_file.append(total_count)


### PR DESCRIPTION
Current data_utils has a bug that limits the reading of the terabyte dataset. It throws an error: 
`UnicodeDecodeError: 'utf-8' codec can't decode byte 0x8b in position 1: invalid start byte`

This fix address this issue by allowing gzip files to be opened correctly.