### PR TITLE
Make DLRM work on TPUs, both with fake and Criteo kaggle dataset.

### DIFF
--- a/dlrm_data_pytorch.py
+++ b/dlrm_data_pytorch.py
@@ -266,7 +266,7 @@ class CriteoDataset(Dataset):
 
         if self.memory_map:
             if self.split == 'none' or self.split == 'train':
-                # check if need to swicth to next day and load data
+                # check if need to switch to next day and load data
                 if index == self.offset_per_file[self.day]:
                     # print("day_boundary switch", index)
                     self.day_boundary = self.offset_per_file[self.day]
@@ -503,7 +503,7 @@ def make_criteo_data_and_loaders(args):
             num_workers=args.num_workers,
             collate_fn=collate_wrapper_criteo,
             pin_memory=False,
-            drop_last=False,  # True
+            drop_last=args.drop_last,
         )
 
         test_loader = torch.utils.data.DataLoader(
@@ -513,7 +513,7 @@ def make_criteo_data_and_loaders(args):
             num_workers=args.test_num_workers,
             collate_fn=collate_wrapper_criteo,
             pin_memory=False,
-            drop_last=False,  # True
+            drop_last=args.drop_last,
         )
 
     return train_data, train_loader, test_data, test_loader
@@ -627,7 +627,9 @@ def collate_wrapper_random(list_of_tuples):
             T)
 
 
-def make_random_data_and_loader(args, ln_emb, m_den):
+def make_random_data_and_loader(
+    args, ln_emb, m_den, n_replicas=None, rank=None,
+):
 
     train_data = RandomDataset(
         m_den,
@@ -645,6 +647,14 @@ def make_random_data_and_loader(args, ln_emb, m_den):
         reset_seed_on_access=True,
         rand_seed=args.numpy_rand_seed
     )  # WARNING: generates a batch of lookups at once
+    train_sampler = None
+    if rank is not None:
+        torch.utils.data.distributed.DistributedSampler(
+            train_data,
+            num_replicas=n_replicas,
+            rank=rank,
+            shuffle=True,
+        )
     train_loader = torch.utils.data.DataLoader(
         train_data,
         batch_size=1,
@@ -652,7 +662,8 @@ def make_random_data_and_loader(args, ln_emb, m_den):
         num_workers=args.num_workers,
         collate_fn=collate_wrapper_random,
         pin_memory=False,
-        drop_last=False,  # True
+        drop_last=args.drop_last,
+        sampler=train_sampler,
     )
     return train_data, train_loader
 
@@ -764,7 +775,9 @@ def generate_uniform_input_batch(
                 )
             # sparse indices to be used per embedding
             r = ra.random(sparse_group_size)
-            sparse_group = np.unique(np.round(r * (size - 1)).astype(np.int64))
+            # XXX: why np.unique ? This is producing a different input shape..
+            #sparse_group = np.unique(np.round(r * (size - 1)).astype(np.int64))
+            sparse_group = np.round(r * (size - 1)).astype(np.int64)
             # reset sparse_group_size in case some index duplicates were removed
             sparse_group_size = np.int64(sparse_group.size)
             # store lengths and indices

--- a/dlrm_data_pytorch.py
+++ b/dlrm_data_pytorch.py
@@ -28,7 +28,6 @@ import data_utils
 # numpy
 import numpy as np
 from numpy import random as ra
-import random
 
 # pytorch
 import torch
@@ -790,9 +789,9 @@ def generate_uniform_input_batch(
                     np.round(max([1.0], r * min(size, num_indices_per_lookup)))
                 )
             # sparse indices to be used per embedding
-            sparse_group = np.array(
-                random.sample(list(range(size)), sparse_group_size)
-            ).astype(np.int64)
+            r = ra.random(sparse_group_size)
+            sparse_group = np.round(r * (size - 1)).astype(np.int64)
+            sparse_group_size = np.int64(sparse_group.size)
             # store lengths and indices
             lS_batch_offsets += [offset]
             lS_batch_indices += sparse_group.tolist()

--- a/dlrm_data_pytorch.py
+++ b/dlrm_data_pytorch.py
@@ -28,7 +28,7 @@ import data_utils
 # numpy
 import numpy as np
 from numpy import random as ra
-
+import random
 
 # pytorch
 import torch
@@ -790,12 +790,9 @@ def generate_uniform_input_batch(
                     np.round(max([1.0], r * min(size, num_indices_per_lookup)))
                 )
             # sparse indices to be used per embedding
-            r = ra.random(sparse_group_size)
-            # XXX: why np.unique ? This is producing a different input shape..
-            #sparse_group = np.unique(np.round(r * (size - 1)).astype(np.int64))
-            sparse_group = np.round(r * (size - 1)).astype(np.int64)
-            # reset sparse_group_size in case some index duplicates were removed
-            sparse_group_size = np.int64(sparse_group.size)
+            sparse_group = np.array(
+                random.sample(list(range(size)), sparse_group_size)
+            ).astype(np.int64)
             # store lengths and indices
             lS_batch_offsets += [offset]
             lS_batch_indices += sparse_group.tolist()

--- a/dlrm_s_pytorch.py
+++ b/dlrm_s_pytorch.py
@@ -572,7 +572,7 @@ class DLRM_Net(nn.Module):
     def tpu_local_backward(self, fullbatch_localembs, localbatch_fullembs):
         localbatch_fullgrads = [_.grad for _ in localbatch_fullembs]
         # inv to narrow
-        grad = self._gather_other_samples(localbatch_fullgradsdim=1)
+        grad = self._gather_other_samples(localbatch_fullgrads, dim=1)
         grad = self._partition_to_device(grad)
         assert len(fullbatch_localembs) == len(grad), \
             '{} vs {}'.format(len(fullbatch_localembs), len(grad))

--- a/dlrm_s_pytorch.py
+++ b/dlrm_s_pytorch.py
@@ -185,9 +185,6 @@ class DLRM_Net(nn.Module):
         # build MLP layer by layer
         layers = nn.ModuleList()
         for i in range(0, ln.size - 1):
-            # FIXME:delete
-            np.random.seed(i+1000)
-            torch.manual_seed(i+1000)
             n = ln[i]
             m = ln[i + 1]
 
@@ -258,9 +255,6 @@ class DLRM_Net(nn.Module):
         if self.use_tpu and self.ndevices > 1:
             self._set_up_sparse_feature_info(ln)
         for i in range(0, ln.size):
-            # FIXME:delete
-            np.random.seed(i+100)
-            torch.manual_seed(i+100)
             n = ln[i]
             if (
                 self.use_tpu and
@@ -860,7 +854,6 @@ def main(*_args):
     np.random.seed(args.numpy_rand_seed)
     np.set_printoptions(precision=args.print_precision)
     torch.set_printoptions(precision=args.print_precision)
-    # XXX: does this imply we init the emb tables the same way?
     torch.manual_seed(args.numpy_rand_seed)
 
     use_gpu = args.use_gpu and torch.cuda.is_available()
@@ -871,7 +864,6 @@ def main(*_args):
         import torch_xla.core.xla_model as xm
         import torch_xla.debug.metrics as met
         import torch_xla.distributed.parallel_loader as pl
-        # FIXME:delete
         print = xm.master_print
         device = xm.xla_device()
         print("Using {} TPU core(s)...".format(xm.xrt_world_size()))
@@ -1334,12 +1326,6 @@ def main(*_args):
                 previous_iteration_time = None
 
             for j, (X, lS_o, lS_i, T) in enumerate(train_ld):
-                # FIXME:delete
-                if j < 10:
-                    summarize('{}dat'.format(j), X, lS_o, lS_i, T)
-                    summarize('{}bot'.format(j), *list(dlrm.bot_l.parameters()))
-                    summarize('{}top'.format(j), *list(dlrm.top_l.parameters()))
-                    summarize('{}emb'.format(j), *[e.weight for e in dlrm.emb_l])
                 if j < skip_upto_batch:
                     continue
 
@@ -1486,9 +1472,6 @@ def main(*_args):
                         targets = []
 
                     for i, (X_test, lS_o_test, lS_i_test, T_test) in enumerate(test_ld):
-                        # FIXME: clearn
-                        if not i%20:
-                            print('TEST STEP', i)
                         # early exit if nbatches was set by the user and was exceeded
                         if nbatches > 0 and i >= nbatches:
                             break

--- a/dlrm_s_pytorch.py
+++ b/dlrm_s_pytorch.py
@@ -342,7 +342,6 @@ class DLRM_Net(nn.Module):
         if self.ndevices > 1:
             import torch_xla.core.xla_model as xm
             self._ordinal = xm.get_ordinal()
-            self._local_ordinal = xm.get_local_ordinal()
             self._all_reduce = xm.all_reduce
             self._all_gather = xm.all_gather
             self._all_to_all = xm.all_to_all
@@ -1288,6 +1287,8 @@ def main(*_args):
                     # scaled error gradient propagation
                     # (where we do not accumulate gradients across mini-batches)
                     optimizer.zero_grad()
+                    if use_tpu and not args.tpu_data_parallel:
+                        emb_local_optimizer.zero_grad()
                     # backward pass
                     E.backward()
                     # debug prints (check gradient norm)

--- a/dlrm_s_pytorch.py
+++ b/dlrm_s_pytorch.py
@@ -891,7 +891,9 @@ def main(*_args):
                 'ms/it reporting, turning --print-time off.'
             )
             args.print_time = False
-
+        # XXX: due to https://github.com/pytorch/xla/issues/2446,
+        #      BCELoss can return `nan`  if input not clamped.
+        args.loss_threshold = max(1e-7, args.loss_threshold)
     elif use_gpu:
         torch.cuda.manual_seed_all(args.numpy_rand_seed)
         torch.backends.cudnn.deterministic = True
@@ -1423,10 +1425,10 @@ def main(*_args):
                     gT = 1000.0 * total_time / total_iter if args.print_time else -1
                     total_time = 0
 
-                    gA = total_accu / total_samp
+                    gA = total_accu / float(total_samp)
                     total_accu = 0
 
-                    gL = total_loss / total_samp
+                    gL = total_loss / float(total_samp)
                     total_loss = 0
 
                     str_run_type = "inference" if args.inference_only else "training"

--- a/dlrm_tpu_runner.py
+++ b/dlrm_tpu_runner.py
@@ -1,0 +1,15 @@
+import sys
+import argparse
+
+import torch_xla.distributed.xla_multiprocessing as xmp
+
+from dlrm_s_pytorch import main, parse_args
+
+
+if __name__ == '__main__':
+    pre_spawn_parser = argparse.ArgumentParser()
+    pre_spawn_parser.add_argument(
+        "--tpu-cores", type=int, default=8, choices=[1, 8]
+    )
+    pre_spawn_flags, _ = pre_spawn_parser.parse_known_args()
+    xmp.spawn(main, args=(), nprocs=pre_spawn_flags.tpu_cores)

--- a/tools/xla_embedding_bag.py
+++ b/tools/xla_embedding_bag.py
@@ -1,0 +1,38 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+import torch
+import torch.nn as nn
+
+
+class XlaEmbeddingBag(nn.Module):
+    """
+    nn.EmbeddingBag is not lowered just yet to xla.
+    This performs the same functionality, in an xla compatible, sub-optimal way.
+
+    Warning!: only works with constant offsets atm.
+    """
+
+    def __init__(self, n, m, mode, offset, *args, **kwargs):
+        super(XlaEmbeddingBag, self).__init__()
+        self.n = n
+        self.m = m
+        self.mode = mode
+        self.offset = offset
+        self.embtable = nn.Embedding(n, m, *args, **kwargs)
+
+    def forward(self, sparse_index_group_batch, sparse_offset_group_batch):
+        emb = self.embtable(sparse_index_group_batch)
+        # XXX: only works w/ constant offset atm
+        bsz = emb.size(0) // self.offset
+        emb = emb.reshape(bsz, self.offset, *emb.size()[1:])
+        reduce_fn = getattr(torch, self.mode)
+        return reduce_fn(emb, axis=1)
+        #return reduce_fn(self.embtable(_) for _ in inp_list)
+
+    @property
+    def weight(self):
+        return self.embtable.weight

--- a/tools/xla_embedding_bag.py
+++ b/tools/xla_embedding_bag.py
@@ -21,16 +21,17 @@ class XlaEmbeddingBag(nn.Module):
         self.n = n
         self.m = m
         self.mode = mode
+        self.reduce_fn = getattr(torch, self.mode)
         self.offset = offset
         self.embtable = nn.Embedding(n, m, *args, **kwargs)
 
     def forward(self, sparse_index_group_batch, sparse_offset_group_batch):
         emb = self.embtable(sparse_index_group_batch)
+        return emb
         # XXX: only works w/ constant offset atm
         bsz = emb.size(0) // self.offset
         emb = emb.reshape(bsz, self.offset, *emb.size()[1:])
-        reduce_fn = getattr(torch, self.mode)
-        return reduce_fn(emb, axis=1)
+        return self.reduce_fn(emb, axis=1)
         #return reduce_fn(self.embtable(_) for _ in inp_list)
 
     @property

--- a/tools/xla_embedding_bag.py
+++ b/tools/xla_embedding_bag.py
@@ -27,12 +27,10 @@ class XlaEmbeddingBag(nn.Module):
 
     def forward(self, sparse_index_group_batch, sparse_offset_group_batch):
         emb = self.embtable(sparse_index_group_batch)
-        return emb
         # XXX: only works w/ constant offset atm
         bsz = emb.size(0) // self.offset
         emb = emb.reshape(bsz, self.offset, *emb.size()[1:])
         return self.reduce_fn(emb, axis=1)
-        #return reduce_fn(self.embtable(_) for _ in inp_list)
 
     @property
     def weight(self):

--- a/tricks/qr_embedding_bag.py
+++ b/tricks/qr_embedding_bag.py
@@ -112,7 +112,7 @@ class QREmbeddingBag(nn.Module):
     def __init__(self, num_categories, embedding_dim, num_collisions,
                  operation='mult', max_norm=None, norm_type=2.,
                  scale_grad_by_freq=False, mode='mean', sparse=False,
-                 _weight=None, xla=False):
+                 _weight=None):
         super(QREmbeddingBag, self).__init__()
 
         assert operation in ['concat', 'mult', 'add'], 'Not valid operation!'
@@ -127,7 +127,6 @@ class QREmbeddingBag(nn.Module):
         self.max_norm = max_norm
         self.norm_type = norm_type
         self.scale_grad_by_freq = scale_grad_by_freq
-        self.xla = xla
 
         if self.operation == 'add' or self.operation == 'mult':
             assert self.embedding_dim[0] == self.embedding_dim[1], \
@@ -154,32 +153,17 @@ class QREmbeddingBag(nn.Module):
         nn.init.uniform_(self.weight_q, np.sqrt(1 / self.num_categories))
         nn.init.uniform_(self.weight_r, np.sqrt(1 / self.num_categories))
 
-    def _embed_input(self, input_q, input_r, offsets, per_sample_weights):
-        # XXX
-        if self.xla:
-            raise NotImplementedError('implement tricks later')
-
-        else:
-            embed_q = F.embedding_bag(
-                input_q, self.weight_q, offsets, self.max_norm, self.norm_type,
-                self.scale_grad_by_freq, self.mode, self.sparse,
-                per_sample_weights
-            )
-            embed_r = F.embedding_bag(
-                input_r, self.weight_r, offsets, self.max_norm, self.norm_type,
-                self.scale_grad_by_freq, self.mode, self.sparse,
-                per_sample_weights
-            )
-        return embed_q, embed_r
-
-
     def forward(self, input, offsets=None, per_sample_weights=None):
         input_q = (input / self.num_collisions).long()
         input_r = torch.remainder(input, self.num_collisions).long()
-        embed_q, embed_r = self._embed_input(
-            input_q, input_r, offsets=offsets,
-            per_sample_weights=per_sample_weights,
-        )
+
+        embed_q = F.embedding_bag(input_q, self.weight_q, offsets, self.max_norm,
+                                  self.norm_type, self.scale_grad_by_freq, self.mode,
+                                  self.sparse, per_sample_weights)
+        embed_r = F.embedding_bag(input_r, self.weight_r, offsets, self.max_norm,
+                                  self.norm_type, self.scale_grad_by_freq, self.mode,
+                                  self.sparse, per_sample_weights)
+
         if self.operation == 'concat':
             embed = torch.cat((embed_q, embed_r), dim=1)
         elif self.operation == 'add':


### PR DESCRIPTION
The individual commits are dirty, I suggest reviewing this PR as a whole.

## CHANGES
- Added a tpu runner file.
- `nn.EmbeddingBag` doesn't work on XLA atm, so I added an "XlaEmbeddingBag" class.
- Adapted dlrm_s_pytorch.py so it runs w/ tpus.
  - Added simultaneous model + data parallelism.
  - xla's all_to_all is not very reliable atm, so I use all_gather + narrow to achieve the same result.
- edited data so it samples across data-parallel groups
    - forces drop_last.
    - 2 optimizers, 2 different all-reduces.
- minor typo fixes, refactoring etc.

## TESTED:
This is being tested nightly on TPUs, nightly and 1.6 version, both with fake data and criteo-kaggle.