### PR TITLE
Update dlrm_data_pytorch.py

### DIFF
--- a/dlrm_data_pytorch.py
+++ b/dlrm_data_pytorch.py
@@ -442,7 +442,7 @@ def make_criteo_data_and_loaders(args, offset_to_length_converter=False):
             )
 
             mlperf_logger.log_event(key=mlperf_logger.constants.TRAIN_SAMPLES,
-                                    value=train_data.num_samples)
+                                    value=train_data.num_entries)
 
             train_loader = torch.utils.data.DataLoader(
                 train_data,
@@ -464,7 +464,7 @@ def make_criteo_data_and_loaders(args, offset_to_length_converter=False):
             )
 
             mlperf_logger.log_event(key=mlperf_logger.constants.EVAL_SAMPLES,
-                                    value=test_data.num_samples)
+                                    value=test_data.num_entries)
 
             test_loader = torch.utils.data.DataLoader(
                 test_data,


### PR DESCRIPTION
Was getting a couple errors when using the `--mlperf-bin-loader` parameter.

`Traceback (most recent call last):
  File "dlrm_s_pytorch.py", line 1869, in <module>
    run()
  File "dlrm_s_pytorch.py", line 1080, in run
    train_data, train_ld, test_data, test_ld = dp.make_criteo_data_and_loaders(args)
  File "/workspace/dlrm/dlrm_data_pytorch.py", line 445, in make_criteo_data_and_loaders
    value=train_data.num_samples)
AttributeError: 'CriteoBinDataset' object has no attribute 'num_samples'`
`Traceback (most recent call last):
  File "dlrm_s_pytorch.py", line 1869, in <module>
    run()
  File "dlrm_s_pytorch.py", line 1080, in run
    train_data, train_ld, test_data, test_ld = dp.make_criteo_data_and_loaders(args)
  File "/workspace/dlrm/dlrm_data_pytorch.py", line 467, in make_criteo_data_and_loaders
    value=test_data.num_samples)
AttributeError: 'CriteoBinDataset' object has no attribute 'num_samples'`

I changed `num_samples` to `num_entries` and that seemed to work as intended.