### PR TITLE
Fixed dlrm_s_pytorch.py issue with nightly PyTorch package

### DIFF
--- a/dlrm_s_pytorch.py
+++ b/dlrm_s_pytorch.py
@@ -1480,7 +1480,7 @@ def run():
 
     ext_dist.barrier()
     with torch.autograd.profiler.profile(
-        args.enable_profiling, use_gpu, record_shapes=True
+        args.enable_profiling, use_cuda=use_gpu, record_shapes=True
     ) as prof:
         if not args.inference_only:
             k = 0


### PR DESCRIPTION
Signed-off-by: artemry-nv <artemry@nvidia.com>

Fixed the following issue with nightly PyTorch package:
```# python3 ${ROOT_DIR}/dlrm/dlrm_s_pytorch.py --mini-batch-size=2 --data-size=6
world size: 1, current rank: 0, local rank: 0
Using CPU...
time/loss/accuracy (if enabled):
Traceback (most recent call last):
  File "${ROOT_DIR}/dlrm/dlrm_s_pytorch.py", line 1872, in <module>
    run()
  File "${ROOT_DIR}/dlrm/dlrm_s_pytorch.py", line 1483, in run
    args.enable_profiling, use_gpu, record_shapes=True
TypeError: __init__() takes from 1 to 2 positional arguments but 3 positional arguments (and 1 keyword-only argument) were given```