### PR TITLE
Fix wrong synthetic output to file

### DIFF
--- a/dlrm_data_pytorch.py
+++ b/dlrm_data_pytorch.py
@@ -1186,7 +1186,7 @@ def write_trace_to_file(file_path, trace):
                 np.array(trace).astype(np.uint64).tofile(f)
         else:
             with open(file_path, "w+") as f:
-                s = str(trace)
+                s = str(list(trace))
                 f.write(s[1 : len(s) - 1])
     except Exception:
         print("ERROR: no output trace file has been provided")
@@ -1211,13 +1211,13 @@ def write_dist_to_file(file_path, unique_accesses, list_sd, cumm_sd):
     try:
         with open(file_path, "w") as f:
             # unique_acesses
-            s = str(unique_accesses)
+            s = str(list(unique_accesses))
             f.write(s[1 : len(s) - 1] + "\n")
             # list_sd
             s = str(list_sd)
             f.write(s[1 : len(s) - 1] + "\n")
             # cumm_sd
-            s = str(cumm_sd)
+            s = str(list(cumm_sd))
             f.write(s[1 : len(s) - 1] + "\n")
     except Exception:
         print("Wrong file or file path")
@@ -1280,7 +1280,7 @@ if __name__ == "__main__":
     ### write stack_distance and line_accesses to a file ###
     write_dist_to_file(args.dist_file, line_accesses, list_sd, cumm_sd)
 
-    ### generate correspondinf synthetic ###
+    ### generate corresponding synthetic ###
     # line_accesses, list_sd, cumm_sd = read_dist_from_file(args.dist_file)
     synthetic_trace = trace_generate_lru(
         line_accesses, list_sd, cumm_sd, len(trace), args.trace_enable_padding


### PR DESCRIPTION
Previous commit b9c61a6 change`synthetic_trace`, `cumm_sd`, etc. from list to deque, leading to wrong output to file shown as below:
```
dist.log:
eque([1, 2, 3, 4, 5, 6]
0, 1, 3, 4, 5
eque([0.5454545454545454, 0.6363636363636364, 0.8181818181818181, 0.9090909090909091, 1.0]

trace_synthetic.log:
eque([1, 2, 3, 4, 2, 5, 1, 2, 6, 3, 4]
```
This PR convert it back to list before writing to file.