### PR TITLE
Allow benchmark to run on more than 4 nodes

### DIFF
--- a/extend_distributed.py
+++ b/extend_distributed.py
@@ -164,7 +164,7 @@ def init_distributed(rank=-1, local_rank=-1, size=-1, use_gpu=False, backend="")
             print("Running on %d ranks using %s backend" % (my_size, backend))
         if hasattr(dist, "all_to_all_single"):
             try:
-                t = torch.zeros([4])
+                t = torch.zeros([1024])
                 if use_gpu:
                     t = t.cuda()
                 dist.all_to_all_single(t, t)


### PR DESCRIPTION
dist.all_to_all_single(t, t) will fail if length of t is less the number of nodes. Increasing it to 1024 allows it to run on up to 1024 nodes.