### PR TITLE
torch.onnx.export `use_external_data_format` deprecated for torch > 1.11

### DIFF
--- a/dlrm_s_pytorch.py
+++ b/dlrm_s_pytorch.py
@@ -1861,7 +1861,6 @@ def run():
             (X_onnx, lS_o_onnx, lS_i_onnx),
             dlrm_pytorch_onnx_file,
             verbose=True,
-            use_external_data_format=True,
             opset_version=11,
             input_names=all_inputs,
             output_names=["pred"],


### PR DESCRIPTION
torch.onnx.export `use_external_data_format` argument was removed for torch > 1.11