### PR TITLE
Add RestartableMap, to fix validation within epoch when multi_hot ena…

### DIFF
--- a/torchrec_dlrm/dlrm_main.py
+++ b/torchrec_dlrm/dlrm_main.py
@@ -43,14 +43,14 @@ try:
 
     # pyre-ignore[21]
     # @manual=//ai_codesign/benchmarks/dlrm/torchrec_dlrm:multi_hot
-    from multi_hot import Multihot
+    from multi_hot import Multihot, RestartableMap
 except ImportError:
     pass
 
 # internal import
 try:
     from .data.dlrm_dataloader import get_dataloader, STAGES  # noqa F811
-    from .multi_hot import Multihot # noqa F811
+    from .multi_hot import Multihot, RestartableMap # noqa F811
 except ImportError:
     pass
 
@@ -637,9 +637,9 @@ def main(argv: List[str]) -> None:
             type=args.multi_hot_distribution_type,
         )
         multihot.pause_stats_collection_during_val_and_test(train_pipeline._model)
-        train_dataloader = map(multihot.convert_to_multi_hot, train_dataloader)
-        val_dataloader = map(multihot.convert_to_multi_hot, val_dataloader)
-        test_dataloader = map(multihot.convert_to_multi_hot, test_dataloader)
+        train_dataloader = RestartableMap(multihot.convert_to_multi_hot, train_dataloader)
+        val_dataloader = RestartableMap(multihot.convert_to_multi_hot, val_dataloader)
+        test_dataloader = RestartableMap(multihot.convert_to_multi_hot, test_dataloader)
     train_val_test(
         args, train_pipeline, train_dataloader, val_dataloader, test_dataloader
     )

--- a/torchrec_dlrm/multi_hot.py
+++ b/torchrec_dlrm/multi_hot.py
@@ -8,6 +8,15 @@ import numpy as np
 from torchrec.datasets.utils import Batch
 from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
 
+class RestartableMap:
+    def __init__(self, f, source):
+        self.source = source
+        self.func = f
+
+    def __iter__(self):
+        for x in self.source:
+            yield self.func(x)
+
 class Multihot():
     def __init__(
         self,
@@ -59,7 +68,7 @@ class Multihot():
     ) -> List[np.array]:
         cache = [ np.zeros((rows_count, multi_hot_size)) for rows_count in ln_emb ]
         for k, e in enumerate(ln_emb):
-            np.random.seed(k) # The seed is necessary for all ranks produce the same lookup values.
+            np.random.seed(k) # The seed is necessary for all ranks to produce the same lookup values.
             if type == "uniform":
                 cache[k][:,1:] = np.random.randint(0, e, size=(e, multi_hot_size-1))
             elif type == "pareto":


### PR DESCRIPTION
…bled.

Map does not automatically bind with subsequent iterators returned by the dataloader. This causes subsequent validation runs to exit early when running multiple validations within one epoch.  The RestartableMap implementation solves this problem.