### PR TITLE
Typo fix

### DIFF
--- a/torchrec_dlrm/dlrm_main.py
+++ b/torchrec_dlrm/dlrm_main.py
@@ -634,7 +634,7 @@ def main(argv: List[str]) -> None:
             args.num_embeddings_per_feature,
             args.batch_size,
             collect_freqs_stats=args.collect_multi_hot_freqs_stats,
-            type=args.multi_hot_distribution_type,
+            dist_type=args.multi_hot_distribution_type,
         )
         multihot.pause_stats_collection_during_val_and_test(train_pipeline._model)
         train_dataloader = RestartableMap(multihot.convert_to_multi_hot, train_dataloader)

--- a/torchrec_dlrm/multi_hot.py
+++ b/torchrec_dlrm/multi_hot.py
@@ -25,13 +25,14 @@ class Multihot():
         ln_emb: List[int],
         batch_size: int,
         collect_freqs_stats: bool,
-        type: str = "uniform",
+        dist_type: str = "uniform",
     ):
-        if type != "uniform" and type != "pareto":
+        if dist_type not in {"uniform", "pareto"}:
             raise ValueError(
                 "Multi-hot distribution type {} is not supported."
-                "Only \"uniform\" and \"pareto\" are supported.".format(type)
+                "Only \"uniform\" and \"pareto\" are supported.".format(dist_type)
             )
+        self.dist_type = dist_type
         self.multi_hot_min_table_size = multi_hot_min_table_size
         self.multi_hot_size = multi_hot_size
         self.batch_size = batch_size
@@ -69,9 +70,9 @@ class Multihot():
         cache = [ np.zeros((rows_count, multi_hot_size)) for rows_count in ln_emb ]
         for k, e in enumerate(ln_emb):
             np.random.seed(k) # The seed is necessary for all ranks to produce the same lookup values.
-            if type == "uniform":
+            if self.dist_type == "uniform":
                 cache[k][:,1:] = np.random.randint(0, e, size=(e, multi_hot_size-1))
-            elif type == "pareto":
+            elif self.dist_type == "pareto":
                 cache[k][:,1:] = np.random.pareto(a=0.25, size=(e, multi_hot_size-1)).astype(np.int32) % e
         # cache axes are [table, batch, offset]
         cache = [ torch.from_numpy(table_cache).int() for table_cache in cache ]


### PR DESCRIPTION
I'm fixing an issue with choosing distribution type within `Multihot` class: it uses `type` variable which shadows Python built-in function which, in turn, shadows a problem with comparisons like `type == "uniform"` in `__make_multi_hot_indices_cache` method.