### PR TITLE
Add DCNv2 to the interaction layer in DLRM (#506)

### DIFF
--- a/torchrec_dlrm/tests/test_dlrm_main.py
+++ b/torchrec_dlrm/tests/test_dlrm_main.py
@@ -98,3 +98,51 @@ class MainTest(unittest.TestCase):
             )
 
             elastic_launch(config=lc, entrypoint=self._run_trainer_criteo_in_memory)()
+
+    @classmethod
+    def _run_trainer_dcn(cls) -> None:
+        with CriteoTest._create_dataset_npys(
+            num_rows=50, filenames=[f"day_{i}" for i in range(24)]
+        ) as files:
+            main(
+                [
+                    "--over_arch_layer_sizes",
+                    "8,1",
+                    "--dense_arch_layer_sizes",
+                    "8,8",
+                    "--embedding_dim",
+                    "8",
+                    "--num_embeddings",
+                    "64",
+                    "--batch_size",
+                    "2",
+                    "--in_memory_binary_criteo_path",
+                    os.path.dirname(files[0]),
+                    "--epochs",
+                    "2",
+                    "--interaction_type",
+                    "dcn",
+                    "--dcn_num_layers",
+                    "2",
+                    "--dcn_low_rank_dim",
+                    "8",
+                ]
+            )
+
+    @test_utils.skip_if_asan
+    def test_main_function_dcn(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            lc = LaunchConfig(
+                min_nodes=1,
+                max_nodes=1,
+                nproc_per_node=2,
+                run_id=str(uuid.uuid4()),
+                rdzv_backend="c10d",
+                rdzv_endpoint=os.path.join(tmpdir, "rdzv"),
+                rdzv_configs={"store_type": "file"},
+                start_method="spawn",
+                monitor_interval=1,
+                max_restarts=0,
+            )
+
+            elastic_launch(config=lc, entrypoint=self._run_trainer_dcn)()


### PR DESCRIPTION
Summary:
X-link: https://github.com/pytorch/torchrec/pull/506

Add DCNv2 to interaction layer. We create a new DLRM_DCN module which uses DCN as the interaction in DLRM. This can be instantiated for training with the --interaction flag (replaces the --dlrmv2 boolean flag) and DCN parameters --dcn_num_layers and --dcn_low_rank_dim.

Run with torchx as
torchx run -s local_cwd dist.ddp -j 1x8 --script dlrm_main.py -- --pin_memory --batch_size 2048 --epochs 1 --num_embeddings_per_feature "45833188,36746,17245,7413,20243,3,7114,1441,62,29275261,1572176,345138,10,2209,11267,128,4,974,14,48937457,11316796,40094537,452104,12606,104,35" --embedding_dim 128 --dense_arch_layer_sizes "512,256,128" --over_arch_layer_sizes "1024,1024,512,256,1" --in_memory_binary_criteo_path $PATH_TO_1TB_NUMPY_FILES --learning_rate 0.01 --adagrad --mmap_mode --validation_freq_within_epoch 10000 --interaction_type="dcn" --dcn_num_layers=3 --dcn_low_rank_dim=512

Reviewed By: colin2328

Differential Revision: D37323271

