### PR TITLE
Multi-hot sampling based on the "true" category distirbution

### DIFF
--- a/torchrec_dlrm/scripts/compute_category_prob.py
+++ b/torchrec_dlrm/scripts/compute_category_prob.py
@@ -1,0 +1,103 @@
+import argparse
+import os
+import pickle
+from collections import Counter
+from concurrent.futures import ProcessPoolExecutor, as_completed
+from typing import Dict, List, Tuple
+
+import numpy as np
+from tqdm import tqdm
+
+CAT_FEATURE_COUNT = 26
+DAYS = 24
+NUM_TOTAL_SAMPLES = 4373472329
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Compute category distribution for each column of Criteo dataset"
+    )
+    parser.add_argument(
+        "--data_dir",
+        type=str,
+        required=True,
+        help="Directory with preprocessed data"
+    )
+    parser.add_argument(
+        "--results_dir",
+        type=str,
+        required=True,
+        help="Directory to save results"
+    )
+    parser.add_argument(
+        "--num_embeddings_per_feature",
+        type=int,
+        nargs="+",
+        help="The number of embeddings in each table: 26 values are expected for the Criteo dataset."
+    )
+    parser.add_argument(
+        "--results_file",
+        type=str,
+        default="category_prob.pkl",
+        help="File to save pickled category probabilities"
+    )
+    parser.add_argument(
+        "--num_workers",
+        type=int,
+        default=CAT_FEATURE_COUNT,
+        help="The maximal number of workers for processing data columns in parallel"
+    )
+    return parser.parse_args()
+
+
+def load_data(file_path: str) -> np.ndarray:
+    data = np.load(file_path)
+    data = np.reshape(data, (-1, CAT_FEATURE_COUNT), order='C')
+    return data
+
+
+def value_counts(column: np.ndarray, n: int, i: int) -> Tuple[np.ndarray, int]:
+    counts = np.zeros(n, dtype=np.int64)
+    counter = Counter(column % n)
+    val = list(counter)
+    cnt = np.fromiter(counter.values(), dtype=np.int64)
+    counts[val] = cnt
+    return counts, i
+
+
+def get_category_count(data_dir: str, num_embeddings_per_feature: List[int], num_workers: int) -> Dict[int, np.ndarray]:
+    category_count = {i: np.zeros(num_embeddings_per_feature[i], dtype=np.int64) for i in range(CAT_FEATURE_COUNT)}
+    for d in tqdm(range(DAYS)):
+        data = load_data(os.path.join(data_dir, f"day_{d}_sparse.npy"))
+        with ProcessPoolExecutor(max_workers=num_workers) as executor:
+            futures = [executor.submit(value_counts, data[:, i], n, i) for i, n in enumerate(num_embeddings_per_feature)]
+            for future in as_completed(futures):
+                counts, i = future.result()
+                category_count[i] += counts
+    return category_count
+
+
+def get_category_prob(category_counts: Dict[int, np.ndarray]) -> Dict[int, np.ndarray]:
+    category_prob = {}
+    for i in tqdm(category_counts):
+        category_prob[i] = np.divide(category_counts[i], NUM_TOTAL_SAMPLES, dtype=np.float32)
+    return category_prob
+
+
+def main():
+    args = parse_args()
+    assert os.path.isdir(args.results_dir)
+    assert len(args.num_embeddings_per_feature) == CAT_FEATURE_COUNT
+
+    print("Computing category distribution for all columns")
+    category_count = get_category_count(args.data_dir, args.num_embeddings_per_feature, args.num_workers)
+    category_prob = get_category_prob(category_count)
+
+    with open(os.path.join(args.results_dir, args.results_file), "wb") as f:
+        pickle.dump(category_prob, f)
+
+    print("Done.")
+
+
+if __name__ == "__main__":
+    main()

--- a/torchrec_dlrm/scripts/generate_multi_hot_tables.py
+++ b/torchrec_dlrm/scripts/generate_multi_hot_tables.py
@@ -1,0 +1,60 @@
+import argparse
+import os
+import pickle
+
+import numpy as np
+from tqdm import tqdm
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Generate cache for multi-hot sampling according to category distribution given"
+    )
+    parser.add_argument(
+        "--category_prob_file",
+        type=str,
+        required=True,
+        help="Pickled file with category distribution per column"
+    )
+    parser.add_argument(
+        "--results_dir",
+        type=str,
+        required=True,
+        help="Directory to save results"
+    )
+    parser.add_argument(
+        "--multi_hot_size",
+        type=int,
+        default=20,
+        help="The target number of multi-hot indices"
+    )
+    parser.add_argument(
+        "--random_seed",
+        type=int,
+        default=0,
+        help="Random seed for reproducibility"
+    )
+    return parser.parse_args()
+
+
+def main(category_prob_file: str, output_dir: str, multi_hot_size: int, seed: int):
+    with open(category_prob_file, "rb") as f:
+        category_prob = pickle.load(f)
+
+    print("Generating multi-hot tables according to distribution given")
+
+    np.random.seed(seed)
+    for i, p in tqdm(category_prob.items()):
+        n = len(p)
+        cache = np.random.choice(n, size=(n, multi_hot_size), replace=True, p=p)
+        cache[:, 0] = 0  # The first column is reserved for the original category
+        with open(os.path.join(output_dir, f"multi_hot_table_{i:0>2}.npy"), "wb") as f:
+            np.save(f, cache)
+
+    print("Done.")
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    assert os.path.isdir(args.results_dir)
+    main(args.category_prob_file, args.results_dir, args.multi_hot_size, args.random_seed)


### PR DESCRIPTION
I'm adding new distribution sampling type for multi-hot indices: **"precomputed"**.

1. `torchrec_dlrm/scripts/compute_category_prob.py` derives the "original" category distribution from Criteo dataset
2. `torchrec_dlrm/scripts/generate_multi_hot_tables.py` dumps cache used for multi-hot sampling [here](https://github.com/janekl/dlrm/blob/d2384346de736ae474de967013d79c28b6730209/torchrec_dlrm/multi_hot.py#L82-L83) based on category distribution from (1).
3. `torchrec_dlrm/multi_hot.py` is adapted to consume tables dumped in (2) as the cache.

Step (2) is introduced for performance reasons as it is much faster to load precomputed data than to generate it on the fly using, for example, `np.random.choice` (that allows sampling according to any distribution which is our goal here).

Example command to train DLRM using the distribution type proposed is:
```
torchx run -s local_cwd dist.ddp -j 1x8 --script dlrm_main.py -- \
        --embedding_dim 128 \
        --dense_arch_layer_sizes 512,256,128 \
        --over_arch_layer_sizes 1024,1024,512,256,1 \
        --shuffle_batches \
        --validation_freq_within_epoch 25605 \
        --in_memory_binary_criteo_path /data/processed \
        --batch_size 2048 \
        --num_embeddings_per_feature 45833188,36746,17245,7413,20243,3,7114,1441,62,29275261,1572176,345138,10,2209,11267,128,4,974,14,48937457,11316796,40094537,452104,12606,104,35 \
        --epochs 1 \
        --pin_memory \
        --mmap_mode \
        --adagrad \
        --learning_rate 0.01 \
        --multi_hot_size 20 \
        --multi_hot_tables 3 4 15 17 19 21 \
        --multi_hot_distribution_type precomputed \
        --multi_hot_precomputed_dir /data/cache_precomputed \
        --collect_multi_hot_freqs_stats
```

Moreover, I'm replacing `--multi_hot_min_table_size` with `--multi_hot_tables` parameter which exactly specifies the categories to covert to multi-hot but offers greater flexibility. You can use `--multi_hot_tables 0 1 2 3 4 6 7 9 10 11 13 14 17 19 20 21 22 23` now to achieve the same results as with `--multi_hot_min_table_size 200` previously.