### PR TITLE
Add bash script that simplifies into one command the execution of all 3 preprocessing steps for the criteo 1tb click logs dataset. Prevent attempting to process wrong files merely because a file is in the same directory as the dataset files. (#694)

### DIFF
--- a/torchrec_dlrm/README.MD
+++ b/torchrec_dlrm/README.MD
@@ -73,38 +73,22 @@ For an alternative way of preprocessing the dataset using NVTabular, which can d
 
 Preprocessing command (numpy):
 
-```
-git clone torchrec
-cd torchrec/datasets/scripts/
+After downloading and uncompressing the [Criteo 1TB Click Logs dataset](https://storage.googleapis.com/criteo-cail-datasets/day_{0-23}.gz), process the raw tsv files into the proper format for training by running `./scripts/process_Criteo_1TB_Click_Logs_dataset.sh` with necessary command line arguments.
 
-After downloading the [Criteo 1TB Click Logs dataset](https://storage.googleapis.com/criteo-cail-datasets/day_{0-23}.gz), the tsv files must be preprocessed to ensure they're in the proper format for training.
-Run the following scripts to preprocess:
-
-1. `npy_preproc_criteo.py` - Split the dataset into dense, sparse and labels (~24hrs)
-
-For example:
-
-python npy_preproc_criteo.py --input_dir /path_to_raw_files_dir --output_path $PATH_TO_1TB_NUMPY_FILES
-
-# path_to_raw_files_dir should contain the raw TSV criteo files downloaded from
-
-2. `contiguous_preproc_criteo.py` - Convert all sparse.npy files to have contiguous integers.
-
-python contiguous_preproc_criteo.py --input_dir $PATH_TO_1TB_NUMPY_FILES --output_dir $PATH_TO_1TB_NUMPY_FILES_CONTIGUOUS --frequency_threshold 0
-
-# frequency_threshold = 0 disables this feature. Set it to any value >= 2 for it to take effect.
-
-3. `shuffle_preproc_criteo.py` - Shuffle the split dataset. (~20hrs)
-
-python shuffle_preproc_criteo.py --input_dir_labels_and_dense $PATH_TO_1TB_NUMPY_FILES --input_dir_sparse $PATH_TO_1TB_NUMPY_FILES_CONTIGUOUS --output_dir_shuffled $PATH_TO_1TB_NUMPY_FILES_CONTIGUOUS_SHUFFLED --random_seed 0
-
-
-MD5 checksums of the final preprocessed dataset files are in md5sums_preprocessed_criteo_click_logs_dataset.txt
-These scripts take 700GB of RAM to run, and can take several (4-5) days to run. We currently have features in development to reduce the preproccessing time and memory overhead.
-
-# We are working on improving this experience, for updates about this see https://github.com/pytorch/torchrec/tree/main/examples/nvt_dataloader
+Example usage:
 
 ```
+bash ./scripts/process_Criteo_1TB_Click_Logs_dataset.sh \
+./criteo_1tb/raw_input_dataset_dir \
+./criteo_1tb/temp_intermediate_files_dir \
+./criteo_1tb/numpy_contiguous_shuffled_output_dataset_dir
+```
+
+The script requires 700GB of RAM and can take several (4-5) days to run. We currently have features in development to reduce the preproccessing time and memory overhead.
+MD5 checksums of the expected final preprocessed dataset files are in md5sums_preprocessed_criteo_click_logs_dataset.txt.
+
+We are working on improving this experience, for updates about this see https://github.com/pytorch/torchrec/tree/main/examples/nvt_dataloader
+
 
 Example command:
 ```

--- a/torchrec_dlrm/scripts/process_Criteo_1TB_Click_Logs_dataset.sh
+++ b/torchrec_dlrm/scripts/process_Criteo_1TB_Click_Logs_dataset.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+display_help() {
+   echo "Three command line arguments are required."
+   echo "Example usage:"
+   echo "bash process_Criteo_1TB_Click_Logs_dataset.sh \\"
+   echo "./criteo_1tb/raw_input_dataset_dir \\"
+   echo "./criteo_1tb/temp_intermediate_files_dir \\"
+   echo "./criteo_1tb/numpy_contiguous_shuffled_output_dataset_dir"
+   exit 1
+}
+
+[ -z "$1" ] && display_help
+[ -z "$2" ] && display_help
+[ -z "$3" ] && display_help
+
+# Input directory containing the raw Criteo 1TB Click Logs dataset files in tsv format.
+# The 24 dataset filenames in the directory should be day_{0..23} with no .tsv extension.
+raw_tsv_criteo_files_dir=$(readlink -m "$1")
+
+# Directory to store temporary intermediate output files created by preprocessing steps 1 and 2.
+temp_files_dir=$(readlink -m "$2")
+
+# Directory to store temporary intermediate output files created by preprocessing step 1.
+step_1_output_dir="$temp_files_dir/temp_output_of_step_1"
+
+# Directory to store temporary intermediate output files created by preprocessing step 2.
+step_2_output_dir="$temp_files_dir/temp_output_of_step_2"
+
+# Directory to store the final preprocessed Criteo 1TB Click Logs dataset.
+step_3_output_dir=$(readlink -m "$3")
+
+# Step 1. Split the dataset into 3 sets of 24 numpy files:
+# day_{0..23}_dense.npy, day_{0..23}_labels.npy, and day_{0..23}_sparse.npy (~24hrs)
+set -x
+mkdir -p "$step_1_output_dir"
+date
+python -m torchrec.datasets.scripts.npy_preproc_criteo --input_dir "$raw_tsv_criteo_files_dir" --output_dir "$step_1_output_dir" || exit
+
+# Step 2. Convert all sparse indices in day_{0..23}_sparse.npy to contiguous indices and save the output.
+# The output filenames are day_{0..23}_sparse_contig_freq.npy
+mkdir -p "$step_2_output_dir"
+date
+python -m torchrec.datasets.scripts.contiguous_preproc_criteo --input_dir "$step_1_output_dir" --output_dir "$step_2_output_dir" --frequency_threshold 0 || exit
+
+date
+for i in {0..23}
+do
+   name="$step_2_output_dir/day_$i""_sparse_contig_freq.npy"
+   renamed="$step_2_output_dir/day_$i""_sparse.npy"
+   echo "Renaming $name to $renamed"
+   mv "$name" "$renamed"
+done
+
+# Step 3. Shuffle the dataset's samples in days 0 through 22. (~20hrs)
+# Day 23's samples are not shuffled and will be used for the validation set and test set.
+mkdir -p "$step_3_output_dir"
+date
+python -m torchrec.datasets.scripts.shuffle_preproc_criteo --input_dir_labels_and_dense "$step_1_output_dir" --input_dir_sparse "$step_2_output_dir" --output_dir_shuffled "$step_3_output_dir" --random_seed 0 || exit
+date


### PR DESCRIPTION
Summary:
X-link: https://github.com/pytorch/torchrec/pull/694

Add bash script that simplifies into one command the execution of all 3 preprocessing steps for the Criteo 1TB Click Logs dataset.

Prevent attempting to process wrong file(s) merely because the file(s) are in the same directory as the dataset files.

Differential Revision: D40122871

