### PR TITLE
Fix broken tests in test_dlrm_main introduced by D40080777

### DIFF
--- a/torchrec_dlrm/dlrm_main.py
+++ b/torchrec_dlrm/dlrm_main.py
@@ -361,7 +361,7 @@ def _evaluate(
                 break
     auroc_result = auroc.compute().item()
     accuracy_result = accuracy.compute().item()
-    num_samples = torch.tensor(sum(map(len, auroc.target)), device=torch.cuda.current_device())
+    num_samples = torch.tensor(sum(map(len, auroc.target)), device=device)
     dist.reduce(num_samples, 0, op=dist.ReduceOp.SUM)
     if dist.get_rank() == 0:
         print(f"AUROC over {stage} set: {auroc_result}.")


### PR DESCRIPTION
Summary:
The three tests in test_dlrm_main.py were broken from Oct. 7th. The error message is:

```
  (1) ai_codesign.benchmarks.dlrm.torchrec_dlrm.tests.test_dlrm_main.MainTest: test_main_function
    1) ChildFailedError:
    ============================================================
    _run_trainer_random FAILED
    ------------------------------------------------------------
    Failures:
      <NO_OTHER_FAILURES>
    ------------------------------------------------------------
    Root Cause (first observed failure):
    [0]:
      time      : 2022-10-07_23:44:36
      host      : twshared33559.02.odn2.facebook.com
      rank      : 0 (local_rank: 0)
      exitcode  : 1 (pid: 912305)
      error_file: /tmp/torchelastic_rbogfx23/5a186e57-e0ea-4c33-94d9-8a8546ba489f_11a3xm9l/attempt_0/0/error.json
      traceback : Traceback (most recent call last):
        File "/data/sandcastle/boxes/eden-trunk-hg-fbcode-fbsource/buck-out/v2/gen/fbcode/110b607930331a92/ai_codesign/benchmarks/dlrm/torchrec_dlrm/tests/__test_dlrm_main__/test_dlrm_main#link-tree/torch/distributed/elastic/multiprocessing/errors/__init__.py", line 346, in wrapper
          return f(*args, **kwargs)
        File "/data/sandcastle/boxes/eden-trunk-hg-fbcode-fbsource/buck-out/v2/gen/fbcode/110b607930331a92/ai_codesign/benchmarks/dlrm/torchrec_dlrm/tests/__test_dlrm_main__/test_dlrm_main#link-tree/ai_codesign/benchmarks/dlrm/torchrec_dlrm/tests/test_dlrm_main.py", line 23, in _run_trainer_random
          main(
        File "/data/sandcastle/boxes/eden-trunk-hg-fbcode-fbsource/buck-out/v2/gen/fbcode/110b607930331a92/ai_codesign/benchmarks/dlrm/torchrec_dlrm/tests/__test_dlrm_main__/test_dlrm_main#link-tree/ai_codesign/benchmarks/dlrm/torchrec_dlrm/dlrm_main.py", line 745, in main
          train_val_test(
        File "/data/sandcastle/boxes/eden-trunk-hg-fbcode-fbsource/buck-out/v2/gen/fbcode/110b607930331a92/ai_codesign/benchmarks/dlrm/torchrec_dlrm/tests/__test_dlrm_main__/test_dlrm_main#link-tree/ai_codesign/benchmarks/dlrm/torchrec_dlrm/dlrm_main.py", line 566, in train_val_test
          val_accuracy, val_auroc = _evaluate(
        File "/data/sandcastle/boxes/eden-trunk-hg-fbcode-fbsource/buck-out/v2/gen/fbcode/110b607930331a92/ai_codesign/benchmarks/dlrm/torchrec_dlrm/tests/__test_dlrm_main__/test_dlrm_main#link-tree/ai_codesign/benchmarks/dlrm/torchrec_dlrm/dlrm_main.py", line 371, in _evaluate
          num_samples = torch.tensor(sum(map(len, auroc.target)), device=torch.cuda.current_device())
        File "/data/sandcastle/boxes/eden-trunk-hg-fbcode-fbsource/buck-out/v2/gen/fbcode/110b607930331a92/ai_codesign/benchmarks/dlrm/torchrec_dlrm/tests/__test_dlrm_main__/test_dlrm_main#link-tree/torch/cuda/__init__.py", line 550, in current_device
          _lazy_init()
        File "/data/sandcastle/boxes/eden-trunk-hg-fbcode-fbsource/buck-out/v2/gen/fbcode/110b607930331a92/ai_codesign/benchmarks/dlrm/torchrec_dlrm/tests/__test_dlrm_main__/test_dlrm_main#link-tree/torch/cuda/__init__.py", line 227, in _lazy_init
          torch._C._cuda_init()
      RuntimeError: No CUDA GPUs are available

```

The error only appeared on pure-CPU machines. After fixing "device", the three tests are passed.

Reviewed By: samiwilf

Differential Revision: D40582520

