### PR TITLE
Support uneven batch sizes and uneven number of batches across ranks

### DIFF
--- a/torchrec_dlrm/dlrm_main.py
+++ b/torchrec_dlrm/dlrm_main.py
@@ -34,7 +34,7 @@ from torchrec.models.dlrm import DLRM, DLRM_DCN, DLRM_Projection, DLRMTrain
 from torchrec.modules.embedding_configs import EmbeddingBagConfig
 from torchrec.optim.keyed import CombinedOptimizer, KeyedOptimizerWrapper
 from tqdm import tqdm
-
+from torch.distributed.algorithms.join import Join
 
 # OSS import
 try:
@@ -405,7 +405,7 @@ def _train(
             validation_freq_within_epoch is specified.
         epoch (int): Which epoch the model is being trained on.
         epochs (int): Number of epochs to train.
-        batch_size (int): Batch size to use for training.
+        batch_size (int): Local batch size to use for training.
         change_lr (bool): Whether learning rate should be changed part way through
             training.
         lr_change_point (float): The point through training at which learning rate
@@ -442,57 +442,57 @@ def _train(
         else itertools.islice(iterator, limit_train_batches),
         itertools.islice(next_iterator, TRAIN_PIPELINE_STAGES - 1),
     )
-    samples_per_trainer = TOTAL_TRAINING_SAMPLES / dist.get_world_size() * epochs
-    samples_per_trainer_in_one_epoch = TOTAL_TRAINING_SAMPLES / dist.get_world_size()
-    num_batches = samples_per_trainer_in_one_epoch / batch_size
-    # Infinite iterator instead of while-loop to leverage tqdm progress bar.
+    samples_per_trainer_across_epochs = TOTAL_TRAINING_SAMPLES / dist.get_world_size() * epochs
+    samples_per_trainer = TOTAL_TRAINING_SAMPLES / dist.get_world_size()
+    num_batches = samples_per_trainer / batch_size
     is_rank_zero = dist.get_rank() == 0
     if is_rank_zero:
         pbar = tqdm(iter(int, 1), desc=f"Epoch {epoch}", disable=False)
-    for it in itertools.count():
-        try:
-            if is_rank_zero:
-                if print_lr:
-                    for i, g in enumerate(train_pipeline._optimizer.param_groups):
-                        print(f"lr: {it} {i} {g['lr']:.6f}")
-            train_pipeline.progress(combined_iterator)
-            lr_scheduler.step()
-            if change_lr and (
-                (it * batch_size + samples_per_trainer_in_one_epoch * epoch ) / samples_per_trainer > lr_change_point
-            ):  # progress made through the epoch
-                print(f"Changing learning rate to: {lr_after_change_point}")
-                optimizer = train_pipeline._optimizer
-                lr = lr_after_change_point
-                for g in optimizer.param_groups:
-                    g["lr"] = lr
-            if is_rank_zero:
-                pbar.update(1)
-            if (
-                validation_freq_within_epoch
-                and it % validation_freq_within_epoch == validation_freq_within_epoch - (TRAIN_PIPELINE_STAGES - 1)
-                and it < num_batches - (TRAIN_PIPELINE_STAGES - 1)
-            ):
-                combined_iterator = itertools.chain(
-                    itertools.islice(iter(within_epoch_val_dataloader), TRAIN_PIPELINE_STAGES - 1),
-                    combined_iterator,
-                )
-            if (
-                validation_freq_within_epoch
-                and it > 0
-                and it % validation_freq_within_epoch == 0
-            ):
-                _evaluate(
-                    limit_val_batches,
-                    train_pipeline,
-                    itertools.islice(iter(within_epoch_val_dataloader), TRAIN_PIPELINE_STAGES - 1, None),
-                    iterator,
-                    "val",
-                )
-                train_pipeline._model.train()
-        except StopIteration:
-            if is_rank_zero:
-                print("Total number of iterations:", it)
-            break
+    with Join(list(train_pipeline._model.children())):
+        for it in itertools.count():
+            try:
+                if is_rank_zero:
+                    if print_lr:
+                        for i, g in enumerate(train_pipeline._optimizer.param_groups):
+                            print(f"lr: {it} {i} {g['lr']:.6f}")
+                train_pipeline.progress(combined_iterator)
+                lr_scheduler.step()
+                if change_lr and (
+                    (it * batch_size + samples_per_trainer * epoch ) / samples_per_trainer_across_epochs > lr_change_point
+                ):
+                    print(f"Changing learning rate to: {lr_after_change_point}")
+                    optimizer = train_pipeline._optimizer
+                    lr = lr_after_change_point
+                    for g in optimizer.param_groups:
+                        g["lr"] = lr
+                if is_rank_zero:
+                    pbar.update(1)
+                if (
+                    validation_freq_within_epoch
+                    and it % validation_freq_within_epoch == validation_freq_within_epoch - (TRAIN_PIPELINE_STAGES - 1)
+                    and it < num_batches - (TRAIN_PIPELINE_STAGES - 1)
+                ):
+                    combined_iterator = itertools.chain(
+                        itertools.islice(iter(within_epoch_val_dataloader), TRAIN_PIPELINE_STAGES - 1),
+                        combined_iterator,
+                    )
+                if (
+                    validation_freq_within_epoch
+                    and it > 0
+                    and it % validation_freq_within_epoch == 0
+                ):
+                    _evaluate(
+                        limit_val_batches,
+                        train_pipeline,
+                        itertools.islice(iter(within_epoch_val_dataloader), TRAIN_PIPELINE_STAGES - 1, None),
+                        iterator,
+                        "val",
+                    )
+                    train_pipeline._model.train()
+            except StopIteration:
+                if is_rank_zero:
+                    print("Total number of iterations:", it)
+                break
 
 
 @dataclass
@@ -630,7 +630,6 @@ def main(argv: List[str]) -> None:
     if args.num_embeddings_per_feature is not None:
         args.num_embeddings = None
 
-    # TODO add CriteoIterDataPipe support and add random_dataloader arg
     train_dataloader = get_dataloader(args, backend, "train")
     val_dataloader = get_dataloader(args, backend, "val")
     test_dataloader = get_dataloader(args, backend, "test")
@@ -702,7 +701,7 @@ def main(argv: List[str]) -> None:
         else OptimType.EXACT_SGD,
     }
     sharders = [
-        EmbeddingBagCollectionSharder(fused_params=fused_params),
+        EmbeddingBagCollectionSharder(fused_params=fused_params, variable_batch_size=True),
     ]
 
     model = DistributedModelParallel(


### PR DESCRIPTION
Summary: Remove the constraint that ranks must iterate through batches of the exact same size for the exact same number of iterations.  Now each rank's input batch can be a different size containing a different number of samples, and each rank can forward pass or train fewer or more batches than other ranks.

Differential Revision: D40676549

