### PR TITLE
Change test_main_function_dcn val set size from 50 to 100 so each rank has the same number of val batches.

### DIFF
--- a/torchrec_dlrm/tests/test_dlrm_main.py
+++ b/torchrec_dlrm/tests/test_dlrm_main.py
@@ -102,7 +102,7 @@ class MainTest(unittest.TestCase):
     @classmethod
     def _run_trainer_dcn(cls) -> None:
         with CriteoTest._create_dataset_npys(
-            num_rows=50, filenames=[f"day_{i}" for i in range(24)]
+            num_rows=100, filenames=[f"day_{i}" for i in range(24)]
         ) as files:
             main(
                 [


### PR DESCRIPTION
Summary: Make num_batches equal among ranks for test_main_function_dcn to bypass unexpected Join behavior that we're debugging for ddp models using torch.fx + torchrec + torch.nn

Differential Revision: D41168335

