### PR TITLE
Remove dependence on torch.distributed.algorithms.join. Instead size batches such that all ranks always have the same num_batches. This is possible by increasing batch sizes by 1 sample when necessary to keep num_batches equal across ranks.

### DIFF
--- a/torchrec_dlrm/tests/test_dlrm_main.py
+++ b/torchrec_dlrm/tests/test_dlrm_main.py
@@ -102,7 +102,7 @@ class MainTest(unittest.TestCase):
     @classmethod
     def _run_trainer_dcn(cls) -> None:
         with CriteoTest._create_dataset_npys(
-            num_rows=100, filenames=[f"day_{i}" for i in range(24)]
+            num_rows=50, filenames=[f"day_{i}" for i in range(24)]
         ) as files:
             main(
                 [

--- a/torchrec_dlrm/tests/test_dlrm_main.py
+++ b/torchrec_dlrm/tests/test_dlrm_main.py
@@ -102,7 +102,7 @@ class MainTest(unittest.TestCase):
     @classmethod
     def _run_trainer_dcn(cls) -> None:
         with CriteoTest._create_dataset_npys(
-            num_rows=50, filenames=[f"day_{i}" for i in range(24)]
+            num_rows=100, filenames=[f"day_{i}" for i in range(24)]
         ) as files:
             main(
                 [


### PR DESCRIPTION
Summary: Remove dependence on torch.distributed.algorithms.join. Instead size batches such that all ranks always have the same num_batches. This is possible by increasing batch sizes by 1 sample when necessary to keep num_batches equal across ranks.

Differential Revision: D41173248

