### PR TITLE
Add support for in-memory Criteo training set shuffle. Add supporting unit tests

### DIFF
--- a/torchrec_dlrm/data/dlrm_dataloader.py
+++ b/torchrec_dlrm/data/dlrm_dataloader.py
@@ -73,6 +73,8 @@ def _get_in_memory_dataloader(
             rank=dist.get_rank(),
             world_size=dist.get_world_size(),
             shuffle_batches=args.shuffle_batches,
+            shuffle_training_set=args.shuffle_training_set,
+            shuffle_training_set_random_seed=args.seed,
             mmap_mode=args.mmap_mode,
             hashes=args.num_embeddings_per_feature
             if args.num_embeddings is None

--- a/torchrec_dlrm/dlrm_main.py
+++ b/torchrec_dlrm/dlrm_main.py
@@ -212,6 +212,12 @@ def parse_args(argv: List[str]) -> argparse.Namespace:
         help="Shuffle each batch during training.",
     )
     parser.add_argument(
+        "--shuffle_training_set",
+        dest="shuffle_training_set",
+        action="store_true",
+        help="Shuffle the training set in memory. This will override mmap_mode",
+    )
+    parser.add_argument(
         "--validation_freq_within_epoch",
         type=int,
         default=None,
@@ -241,6 +247,7 @@ def parse_args(argv: List[str]) -> argparse.Namespace:
         pin_memory=None,
         mmap_mode=None,
         shuffle_batches=None,
+        shuffle_training_set=None,
         change_lr=None,
     )
     parser.add_argument(


### PR DESCRIPTION
Summary: Add support for in-memory Criteo training set shuffle. Add supporting unit tests

Differential Revision: D41496094

