### PR TITLE
Add __len__ method to RestartableMap (bugfix)

### DIFF
--- a/torchrec_dlrm/multi_hot.py
+++ b/torchrec_dlrm/multi_hot.py
@@ -13,6 +13,7 @@ import numpy as np
 from torchrec.datasets.utils import Batch
 from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
 
+
 class RestartableMap:
     def __init__(self, f, source):
         self.source = source
@@ -21,6 +22,10 @@ class RestartableMap:
     def __iter__(self):
         for x in self.source:
             yield self.func(x)
+
+    def __len__(self):
+        return len(self.source)
+
 
 class Multihot():
     def __init__(


### PR DESCRIPTION
I'm adding `__len__` method to `RestartableMap` so that we can use it in `tqdm` call, for example, [here](https://github.com/facebookresearch/dlrm/blob/359bca884e96835431b03129073408ee75e751db/torchrec_dlrm/dlrm_main.py#L342).