### PR TITLE
Change dataset traversal so all ranks start from consecutive batches at beginning of dataset (#930)

### DIFF
--- a/torchrec_dlrm/dlrm_main.py
+++ b/torchrec_dlrm/dlrm_main.py
@@ -281,7 +281,7 @@ def parse_args(argv: List[str]) -> argparse.Namespace:
         "--multi_hot_distribution_type",
         type=str,
         choices=["uniform", "pareto"],
-        default="uniform",
+        default=None,
         help="Multi-hot distribution options.",
     )
     parser.add_argument("--lr_warmup_steps", type=int, default=0)


### PR DESCRIPTION
Summary:
X-link: https://github.com/pytorch/torchrec/pull/930

Change dataset traversal to interleaved with strided steps so that globally the ranks align with consecutive batches and step with a stride of world_size number of batches, starting from the beginning of the dataset.

Differential Revision: D42378903

