### PR TITLE
Use torchmetrics==0.10.3 because it was stable and worked, and torcheval has some issues.

### DIFF
--- a/torchrec_dlrm/requirements.txt
+++ b/torchrec_dlrm/requirements.txt
@@ -1,3 +1,3 @@
 fbgemm-gpu==0.3.2
-torcheval==0.0.5
+torchmetrics==0.10.3
 torchrec==0.3.2


### PR DESCRIPTION
Summary: Use torchmetrics==0.10.3 because it was stable and worked.

Differential Revision: D42493728

