### PR TITLE
Let OSS/docker use 0.11.0 while 0.10.3 is used internally. Code is compatible with both, so this should work.

### DIFF
--- a/torchrec_dlrm/requirements.txt
+++ b/torchrec_dlrm/requirements.txt
@@ -1,3 +1,3 @@
 fbgemm-gpu==0.3.2
-torchmetrics==0.10.3
+torchmetrics==0.11.0
 torchrec==0.3.2


### PR DESCRIPTION
Summary: Let OSS/docker use 0.11.0 while 0.10.3 is used internally. Code is compatible with both, so this should work.

Differential Revision: D42508459

