### PR TITLE
Align Adagrad's eps parameter for embeddings and dense layers

### DIFF
--- a/torchrec_dlrm/dlrm_main.py
+++ b/torchrec_dlrm/dlrm_main.py
@@ -682,7 +682,7 @@ def main(argv: List[str]) -> None:
 
     def optimizer_with_params():
         if args.adagrad:
-            return lambda params: torch.optim.Adagrad(params, lr=args.learning_rate)
+            return lambda params: torch.optim.Adagrad(params, lr=args.learning_rate, eps=args.eps)
         else:
             return lambda params: torch.optim.SGD(params, lr=args.learning_rate)
 


### PR DESCRIPTION
I'm explicitly specifying `eps` parameter for Adagrad optimizer for both embeddings and dense layers. This fixes a mismatch for that parameter value for caused hy using different defaults by PyTorch and FBGEMM (`1e-10` vs `1e-8`).

Note: this is a "mirror" PR of https://github.com/mlcommons/training/pull/622.