### PR TITLE
Get Criteo Kaggle dataset working with TorchRec-based DLRM

### DIFF
--- a/torchrec_dlrm/README.MD
+++ b/torchrec_dlrm/README.MD
@@ -277,3 +277,32 @@ DLRM v2 uses DCN V2 with low rank approximation.
 DLRM v1 uses the Criteo 1TB Click Logs Dataset, but uses a different preprocessing script ([repo_root/data_utils.py](https://github.com/facebookresearch/dlrm/blob/main/data_utils.py)).
 
 DLRM v2 uses the Criteo 1TB Click Logs Dataset but the sparse features are replaced with a multi-hot dataset.
+
+
+# Criteo Kaggle Display Advertising Challenge dataset usage.
+
+### Download the dataset.
+```
+wget http://go.criteo.net/criteo-research-kaggle-display-advertising-challenge-dataset.tar.gz
+```
+### Uncompress
+```
+tar zxvf criteo-research-kaggle-display-advertising-challenge-dataset.tar.gz
+```
+### Preprocess the dataset to numpy files.
+```
+python -m torchrec.datasets.scripts.npy_preproc_criteo --input_dir $INPUT_PATH --output_dir $OUTPUT_PATH --dataset_name criteo_kaggle
+```
+### Run the benchmark.
+```
+export PREPROCESSED_DATASET=$insert_your_path_here
+export GLOBAL_BATCH_SIZE=16384 ;
+export WORLD_SIZE=8 ;
+torchx run -s local_cwd dist.ddp -j 1x8 --script dlrm_main.py -- \
+    --in_memory_binary_criteo_path $PREPROCESSED_DATASET \
+    --pin_memory \
+    --mmap_mode \
+    --batch_size $((GLOBAL_BATCH_SIZE / WORLD_SIZE)) \
+    --learning_rate 1.0 \
+    --dataset_name criteo_kaggle
+```

--- a/torchrec_dlrm/data/dlrm_dataloader.py
+++ b/torchrec_dlrm/data/dlrm_dataloader.py
@@ -80,7 +80,18 @@ def _get_in_memory_dataloader(
         sparse_part = "sparse_multi_hot.npz"
         datapipe = MultiHotCriteoIterDataPipe
 
-    if stage == "train":
+    if args.dataset_name == "criteo_kaggle":
+        # criteo_kaggle has no validation set, so use 2nd half of training set for now.
+        # Setting stage to "test" will get the 2nd half of the dataset.
+        # Setting root_name to "train" reads from the training set file.
+        (root_name, stage) = ("train", "test") if stage == "val" else stage
+        stage_files: List[List[str]] = [
+            [os.path.join(dir_path, f"{root_name}_dense.npy")],
+            [os.path.join(dir_path, f"{root_name}_{sparse_part}")],
+            [os.path.join(dir_path, f"{root_name}_labels.npy")],
+        ]
+    # criteo_1tb code path uses below two conditionals
+    elif stage == "train":
         stage_files: List[List[str]] = [
             [os.path.join(dir_path, f"day_{i}_dense.npy") for i in range(DAYS - 1)],
             [os.path.join(dir_path, f"day_{i}_{sparse_part}") for i in range(DAYS - 1)],

--- a/torchrec_dlrm/dlrm_main.py
+++ b/torchrec_dlrm/dlrm_main.py
@@ -119,6 +119,7 @@ def parse_args(argv: List[str]) -> argparse.Namespace:
     parser.add_argument(
         "--dataset_name",
         type=str,
+        choices=["criteo_1t", "criteo_kaggle"],
         default="criteo_1t",
         help="dataset for experiment, current support criteo_1tb, criteo_kaggle",
     )


### PR DESCRIPTION
Summary: Get Criteo Kaggle dataset working with TorchRec-based DLRM

Differential Revision: D43161492

