### PR TITLE
Replace hasattr with getattr in ai_codesign/benchmarks/dlrm/torchrec_dlrm/data/dlrm_dataloader.py

### DIFF
--- a/torchrec_dlrm/data/dlrm_dataloader.py
+++ b/torchrec_dlrm/data/dlrm_dataloader.py
@@ -55,7 +55,7 @@ def _get_random_dataloader(
             hash_sizes=args.num_embeddings_per_feature
             if hasattr(args, "num_embeddings_per_feature")
             else None,
-            manual_seed=args.seed if hasattr(args, "seed") else None,
+            manual_seed=getattr(args, "seed", None),
             ids_per_feature=1,
             num_dense=len(DEFAULT_INT_NAMES),
             num_batches=num_batches,


### PR DESCRIPTION
Summary:
The pattern
```
X.Y if hasattr(X, "Y") else Z
```
can be replaced with
```
getattr(X, "Y", Z)
```

The [getattr](https://www.w3schools.com/python/ref_func_getattr.asp) function gives more succinct code than the [hasattr](https://www.w3schools.com/python/ref_func_hasattr.asp) function. Please use it when appropriate.

**This diff is very low risk. Green tests indicate that you can safely Accept & Ship.**

Differential Revision: D44886546

