### PR TITLE
Modify the version check of args.dataset_mutliprocessing suitable for Python3.10 above 

### DIFF
--- a/dlrm_s_pytorch.py
+++ b/dlrm_s_pytorch.py
@@ -1015,7 +1015,8 @@ def run():
     args = parser.parse_args()
 
     if args.dataset_multiprocessing:
-        assert float(sys.version[:3]) > 3.7, (
+
+        assert sys.version_info > (3, 7), (
             "The dataset_multiprocessing "
             + "flag is susceptible to a bug in Python 3.7 and under. "
             + "https://github.com/facebookresearch/dlrm/issues/172"


### PR DESCRIPTION
Hi , 
I recently working on this awesome project , and  I find the version check of args.dataset_mutliprocessing is not suitable for  python version is 3.10 or above. 