### PR TITLE
switched bias initialization to initialize to zeros per standard Xavi…

### DIFF
--- a/dlrm_s_pytorch.py
+++ b/dlrm_s_pytorch.py
@@ -209,8 +209,7 @@ class DLRM_Net(nn.Module):
             mean = 0.0  # std_dev = np.sqrt(variance)
             std_dev = np.sqrt(2 / (m + n))  # np.sqrt(1 / m) # np.sqrt(1 / n)
             W = np.random.normal(mean, std_dev, size=(m, n)).astype(np.float32)
-            std_dev = np.sqrt(1 / m)  # np.sqrt(2 / (m + 1))
-            bt = np.random.normal(mean, std_dev, size=m).astype(np.float32)
+            bt = np.zeros(m).astype(np.float32)
             # approach 1
             LL.weight.data = torch.tensor(W, requires_grad=True)
             LL.bias.data = torch.tensor(bt, requires_grad=True)


### PR DESCRIPTION
…er initialization.  See pdf page 251 in https://proceedings.mlr.press/v9/glorot10a/glorot10a.pdf. As set before, the bias may be initialized to a large negative value, leading to a negative input to Relu. This prevents any training, as all derivatives are zero afterward. 

See downstream issue here: https://github.com/pytorch/benchmark/pull/1927
