### PR TITLE
fix a bug when running in Python 3.10 above 

### DIFF
--- a/dlrm_s_caffe2.py
+++ b/dlrm_s_caffe2.py
@@ -1277,7 +1277,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     if args.dataset_multiprocessing:
-        assert float(sys.version[:3]) > 3.7, (
+        assert sys.version_info[0] >=3 and sys.version_info[1] > 7, (
             "The dataset_multiprocessing "
             + "flag is susceptible to a bug in Python 3.7 and under. "
             + "https://github.com/facebookresearch/dlrm/issues/172"

--- a/dlrm_s_pytorch.py
+++ b/dlrm_s_pytorch.py
@@ -1030,7 +1030,7 @@ def run():
     args = parser.parse_args()
 
     if args.dataset_multiprocessing:
-        assert float(sys.version[:3]) > 3.7, (
+        assert sys.version_info[0] >=3 and sys.version_info[1] > 7, (
             "The dataset_multiprocessing "
             + "flag is susceptible to a bug in Python 3.7 and under. "
             + "https://github.com/facebookresearch/dlrm/issues/172"


### PR DESCRIPTION
The current solution to obtain Python version is not correct when the version is more than 3.9, this fixes the problem