### PR TITLE
Convert directory fbcode/ai_codesign to use the Ruff Formatter

### DIFF
--- a/data_loader_terabyte.py
+++ b/data_loader_terabyte.py
@@ -118,7 +118,6 @@ def _batch_generator(
                 batch_start_idx = samples_in_file - length
 
         while batch_start_idx < samples_in_file - batch_size:
-
             missing_samples = batch_size
             if previous_file is not None:
                 missing_samples -= previous_file["y"].shape[0]
@@ -370,7 +369,6 @@ def _test_bin():
     for i, (old_batch, new_batch) in tqdm(
         enumerate(zip(original_loader, binary_loader)), total=len(dataset_binary)
     ):
-
         for j in range(len(new_batch)):
             if not np.array_equal(old_batch[j], new_batch[j]):
                 raise ValueError("FAILED: Datasets not equal")

--- a/data_utils.py
+++ b/data_utils.py
@@ -862,7 +862,6 @@ def transformCriteoAdData(X_cat, X_int, y, days, data_split, randomize, total_pe
         )
 
     else:
-
         # randomize data
         if randomize == "total":
             indices = np.random.permutation(indices)

--- a/dlrm_data_caffe2.py
+++ b/dlrm_data_caffe2.py
@@ -122,7 +122,6 @@ class CriteoDatasetWMemoryMap(Dataset):
                 self.y = data["y"]  # target
 
     def __getitem__(self, index):
-
         if isinstance(index, slice):
             return [
                 self[idx]

--- a/dlrm_data_pytorch.py
+++ b/dlrm_data_pytorch.py
@@ -259,7 +259,6 @@ class CriteoDataset(Dataset):
             print("Split data according to indices...")
 
     def __getitem__(self, index):
-
         if isinstance(index, slice):
             return [
                 self[idx]
@@ -625,7 +624,6 @@ class RandomDataset(Dataset):
         # torch.manual_seed(numpy_rand_seed)
 
     def __getitem__(self, index):
-
         if isinstance(index, slice):
             return [
                 self[idx]
@@ -700,7 +698,6 @@ def make_random_data_and_loader(
     m_den,
     offset_to_length_converter=False,
 ):
-
     train_data = RandomDataset(
         m_den,
         ln_emb,

--- a/dlrm_s_pytorch.py
+++ b/dlrm_s_pytorch.py
@@ -324,7 +324,6 @@ class DLRM_Net(nn.Module):
             and (ln_top is not None)
             and (arch_interaction_op is not None)
         ):
-
             # save arguments
             self.ndevices = ndevices
             self.output_d = 0
@@ -464,7 +463,6 @@ class DLRM_Net(nn.Module):
 
     #  using quantizing functions from caffe2/aten/src/ATen/native/quantized/cpu
     def quantize_embedding(self, bits):
-
         n = len(self.emb_l)
         self.emb_l_q = [None] * n
         for k in range(n):
@@ -483,7 +481,6 @@ class DLRM_Net(nn.Module):
         self.quantize_bits = bits
 
     def interact_features(self, x, ly):
-
         if self.arch_interaction_op == "dot":
             # concatenate dense and sparse features
             (batch_size, d) = x.shape

--- a/mlperf_logger.py
+++ b/mlperf_logger.py
@@ -8,6 +8,7 @@
 """
 Utilities for MLPerf logging
 """
+
 import os
 
 import torch

--- a/tools/visualize.py
+++ b/tools/visualize.py
@@ -83,9 +83,7 @@ def visualize_embeddings_umap(
     cat_counts=None,
     use_max_count=True,
 ):
-
     for k in range(0, len(emb_l)):
-
         E = emb_l[k].weight.detach().cpu().numpy()
         print("umap", E.shape)
 
@@ -120,7 +118,6 @@ def visualize_embeddings_umap(
         if use_max_count is False or n_vis == E.shape[0]:
             Y = reducer.fit_transform(E[:n_vis, :])
         else:
-
             # select values with couns > 1
             done = False
             min_cnt = 1
@@ -196,9 +193,7 @@ def visualize_embeddings_umap(
 
 
 def visualize_embeddings_tsne(emb_l, output_dir="", max_size=10000):
-
     for k in range(0, len(emb_l)):
-
         E = emb_l[k].weight.detach().cpu()
         print("tsne", E.shape)
 
@@ -243,7 +238,6 @@ def visualize_embeddings_tsne(emb_l, output_dir="", max_size=10000):
 
 
 def analyse_categorical_data(X_cat, n_days=10, output_dir=""):
-
     # analyse categorical variables
     n_vec = len(X_cat)
     n_cat = len(X_cat[0])
@@ -313,7 +307,6 @@ def analyse_categorical_data(X_cat, n_days=10, output_dir=""):
 
 
 def analyse_categorical_counts(X_cat, emb_l=None, output_dir=""):
-
     # analyse categorical variables
     n_vec = len(X_cat)
     n_cat = len(X_cat[0])
@@ -328,7 +321,6 @@ def analyse_categorical_counts(X_cat, emb_l=None, output_dir=""):
     all_counts = []
 
     for i in range(0, n_cat):
-
         cat = all_cat[:, i]
         if emb_l is None:
             s = set(cat)
@@ -373,7 +365,6 @@ def analyse_categorical_counts(X_cat, emb_l=None, output_dir=""):
 
 
 def dlrm_output_wrap(dlrm, X, lS_o, lS_i, T):
-
     all_feat_vec = []
     all_cat_vec = []
     x_vec = None
@@ -458,7 +449,6 @@ def dlrm_output_wrap(dlrm, X, lS_o, lS_i, T):
 
 
 def create_umap_data(dlrm, data_ld, max_size=50000, offset=0, info=""):
-
     all_features = []
     all_X = []
     all_cat = []
@@ -473,7 +463,6 @@ def create_umap_data(dlrm, data_ld, max_size=50000, offset=0, info=""):
         all_z.append([])
 
     for j, (X, lS_o, lS_i, T) in enumerate(data_ld):
-
         if j < offset:
             continue
 
@@ -516,7 +505,6 @@ def plot_all_data_3(
     output_dir="",
     orig_space_dim=0,
 ):
-
     size = 1
     colors = ["red", "green"]
 
@@ -583,7 +571,6 @@ def plot_one_class_3(
     output_dir="",
     orig_space_dim=0,
 ):
-
     size = 1
 
     fig, (ax0, ax1, ax2) = plt.subplots(1, 3)
@@ -642,7 +629,6 @@ def visualize_umap_data(
     output_dir="",
     orig_space_dim=0,
 ):
-
     # all classes
     plot_all_data_3(
         umap_Y=umap_Y,
@@ -777,7 +763,6 @@ def visualize_umap_data(
 
 
 def hdbscan_clustering(umap_data, train_data, test_data, info="", output_dir=""):
-
     clusterer = hdbscan.HDBSCAN(
         min_samples=10, min_cluster_size=500, prediction_data=True
     )
@@ -863,7 +848,6 @@ def visualize_all_data_umap(
     output_dir="",
     umap_metric="euclidean",
 ):
-
     data_ratio = 1
 
     print("creating umap data")
@@ -1042,12 +1026,10 @@ def analyze_model_data(
     skip_data_plots=False,
     umap_metric="euclidean",
 ):
-
     if not os.path.exists(output_dir):
         os.makedirs(output_dir)
 
     if skip_embedding is False:
-
         cat_counts = None
 
         cat_counts = analyse_categorical_counts(
@@ -1086,7 +1068,6 @@ def analyze_model_data(
 
 
 if __name__ == "__main__":
-
     output_dir = ""
 
     ### parse arguments ###
@@ -1173,7 +1154,6 @@ if __name__ == "__main__":
         ln_top = np.array([367, 512, 256, 1])
 
     elif args.dataset == "terabyte":
-
         if args.max_ind_range == 10000000:
             # 2. Criteo Terabyte (see ./bench/dlrm_s_criteo_terabyte.sh [--sub-sample=0.875] --max-in-range=10000000)
             m_spa = 64

--- a/torchrec_dlrm/dlrm_main.py
+++ b/torchrec_dlrm/dlrm_main.py
@@ -416,7 +416,9 @@ def _train(
     n = (
         validation_freq
         if validation_freq
-        else limit_train_batches if limit_train_batches else len(train_dataloader)
+        else limit_train_batches
+        if limit_train_batches
+        else len(train_dataloader)
     )
     for batched_iterator in batched(iterator, n):
         for it in itertools.count(start_it):

--- a/tricks/qr_embedding_bag.py
+++ b/tricks/qr_embedding_bag.py
@@ -166,14 +166,20 @@ class QREmbeddingBag(nn.Module):
             )
             self.reset_parameters()
         else:
-            assert list(_weight[0].shape) == [
-                self.num_embeddings[0],
-                self.embedding_dim[0],
-            ], "Shape of weight for quotient table does not match num_embeddings and embedding_dim"
-            assert list(_weight[1].shape) == [
-                self.num_embeddings[1],
-                self.embedding_dim[1],
-            ], "Shape of weight for remainder table does not match num_embeddings and embedding_dim"
+            assert (
+                list(_weight[0].shape)
+                == [
+                    self.num_embeddings[0],
+                    self.embedding_dim[0],
+                ]
+            ), "Shape of weight for quotient table does not match num_embeddings and embedding_dim"
+            assert (
+                list(_weight[1].shape)
+                == [
+                    self.num_embeddings[1],
+                    self.embedding_dim[1],
+                ]
+            ), "Shape of weight for remainder table does not match num_embeddings and embedding_dim"
             self.weight_q = Parameter(_weight[0])
             self.weight_r = Parameter(_weight[1])
         self.mode = mode


### PR DESCRIPTION
Summary:
Converts the directory specified to use the Ruff formatter in pyfmt

ruff_dog

If this diff causes merge conflicts when rebasing, please run
`hg status -n -0 --change . -I '**/*.{py,pyi}' | xargs -0 arc pyfmt`
on your diff, and amend any changes before rebasing onto latest.
That should help reduce or eliminate any merge conflicts.

allow-large-files
bypass-github-export-checks

Reviewed By: amyreese

Differential Revision: D64115811


